### PR TITLE
Updating the graphql-java version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ repositories {
 
 
 dependencies {
-    compile "com.graphql-java:graphql-java:10.0"
+    compile "com.graphql-java:graphql-java:14.0"
     compile "com.squareup.okhttp3:okhttp:3.2.0"
 
     testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'


### PR DESCRIPTION
The version of com.graphql-java:graphql-java is too old causing problems when used for example with com.graphql-java-kickstart/graphql-spring-boot-starter/7.0.1.

In particular: `java.lang.ClassNotFoundException: graphql.schema.GraphQLCodeRegistry`

It can be solved with an exclusion like this:
```
        <dependency>
            <groupId>com.graphql-java</groupId>
            <artifactId>graphql-java-extended-scalars</artifactId>
            <version>${graphql-java-extended-scalars.version}</version>
            <exclusions>
                <exclusion>
                    <groupId>com.graphql-java</groupId>
                    <artifactId>graphql-java</artifactId>
                </exclusion>
            </exclusions>
        </dependency>
```

But it seems it won't hurt to update the graphql-java version.