### PR TITLE
adding a date time scalar which follows the date time spec 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ repositories {
 
 
 dependencies {
-    compile "com.graphql-java:graphql-java:10.0"
+    compile "com.graphql-java:graphql-java:2020-05-25T00-18-12-74b4855"
     compile "com.squareup.okhttp3:okhttp:3.2.0"
 
     testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'

--- a/src/main/java/graphql/scalars/ExtendedScalars.java
+++ b/src/main/java/graphql/scalars/ExtendedScalars.java
@@ -4,6 +4,7 @@ import graphql.PublicApi;
 import graphql.scalars.alias.AliasedScalar;
 import graphql.scalars.datetime.DateScalar;
 import graphql.scalars.datetime.DateTimeScalar;
+import graphql.scalars.datetime.OffsetDateTimeScalar;
 import graphql.scalars.datetime.TimeScalar;
 import graphql.scalars.java.JavaPrimitives;
 import graphql.scalars.locale.LocaleScalar;
@@ -40,6 +41,12 @@ public class ExtendedScalars {
      * @see java.time.ZonedDateTime
      */
     public static GraphQLScalarType DateTime = new DateTimeScalar();
+
+
+    public static GraphQLScalarType OffsetDateTime(String name) {
+        return OffsetDateTimeScalar.newOffsetDateTimeScalar(name);
+    }
+
 
     /**
      * An RFC-3339 compliant date scalar that accepts string values like `1996-12-19` and produces

--- a/src/main/java/graphql/scalars/datetime/OffsetDateTimeScalar.java
+++ b/src/main/java/graphql/scalars/datetime/OffsetDateTimeScalar.java
@@ -1,0 +1,94 @@
+package graphql.scalars.datetime;
+
+
+import graphql.language.StringValue;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+import graphql.schema.GraphQLScalarType;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+import java.time.temporal.TemporalAccessor;
+import java.util.function.Function;
+
+import static graphql.scalars.util.Kit.typeName;
+import static graphql.schema.GraphQLScalarType.newScalar;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.OFFSET_SECONDS;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+
+/**
+ * A Scalar representing an Date and time and offset following the specification at https://www.graphql-scalars.com/date-time.
+ */
+public class OffsetDateTimeScalar {
+
+    private static final DateTimeFormatter formatter = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE)
+            .appendLiteral('T')
+            .appendValue(HOUR_OF_DAY, 2)
+            .appendLiteral(':')
+            .appendValue(MINUTE_OF_HOUR, 2)
+            .appendLiteral(':')
+            .appendValue(SECOND_OF_MINUTE, 2)
+            .appendFraction(MILLI_OF_SECOND, 3, 3, true)
+            .appendPattern("XXX") // Offset in +HH:MM or 'Z'
+            .parseStrict()
+            .toFormatter()
+            .withResolverStyle(ResolverStyle.STRICT);
+
+    // package private for testing
+    static Coercing<OffsetDateTime, String> coercing = new Coercing<OffsetDateTime, String>() {
+
+        @Override
+        public String serialize(Object dataFetcherResult) throws CoercingSerializeException {
+            if (dataFetcherResult instanceof OffsetDateTime) {
+                return formatter.format((TemporalAccessor) dataFetcherResult);
+            }
+            throw new CoercingSerializeException("Not accepted value " + dataFetcherResult);
+        }
+
+        @Override
+        public OffsetDateTime parseValue(Object input) throws CoercingParseValueException {
+            return null;
+        }
+
+        @Override
+        public OffsetDateTime parseLiteral(Object input) throws CoercingParseLiteralException {
+            if (!(input instanceof StringValue)) {
+                throw new CoercingParseLiteralException(
+                        "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
+                );
+            }
+            return parseOffsetDateTime(((StringValue) input).getValue(), CoercingParseLiteralException::new);
+        }
+
+        private OffsetDateTime parseOffsetDateTime(String s, Function<String, RuntimeException> exceptionMaker) {
+            try {
+                OffsetDateTime parse = OffsetDateTime.parse(s, formatter);
+                if (parse.get(OFFSET_SECONDS) == 0 && s.endsWith("-00:00")) {
+                    throw exceptionMaker.apply("Invalid value : '" + s + "'. because negative zero offset is not allowed");
+                }
+                return parse;
+            } catch (DateTimeParseException e) {
+                throw exceptionMaker.apply("Invalid value : '" + s + "'. because of : '" + e.getMessage() + "'");
+            }
+        }
+    };
+
+    public static GraphQLScalarType newOffsetDateTimeScalar(String name) {
+        return newScalar()
+                .name(name)
+                .specifiedByUrl("https://www.graphql-scalars.com/date-time")
+                .coercing(coercing)
+                .build();
+    }
+}

--- a/src/test/groovy/graphql/scalars/datetime/OffsetDateTimeScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/OffsetDateTimeScalarTest.groovy
@@ -1,0 +1,63 @@
+package graphql.scalars.datetime
+
+import graphql.language.StringValue
+import graphql.schema.CoercingParseLiteralException
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static graphql.scalars.util.TestKit.mkOffsetDT
+
+class OffsetDateTimeScalarTest extends Specification {
+
+    @Unroll
+    def "parse literal success for #input"() {
+
+        when:
+        def result = OffsetDateTimeScalar.coercing.parseLiteral(new StringValue(input))
+        then:
+        result == expectedValue
+        where:
+        input                           | expectedValue
+        "2011-08-30T13:22:53.108Z"      | mkOffsetDT("2011-08-30T13:22:53.108Z")
+        "2011-08-30t13:22:53.108Z"      | mkOffsetDT("2011-08-30T13:22:53.108Z")
+        "2011-08-30T13:22:53.108z"      | mkOffsetDT("2011-08-30T13:22:53.108Z")
+        "2011-08-30T13:22:53.108+00:00" | mkOffsetDT("2011-08-30T13:22:53.108+00:00")
+        "2011-08-30T13:22:53.108-03:00" | mkOffsetDT("2011-08-30T13:22:53.108-03:00")
+        "2011-08-30T13:22:53.108+03:00" | mkOffsetDT("2011-08-30T13:22:53.108+03:00")
+    }
+
+    @Unroll
+    def "parse literal failure for #input #reason"() {
+        when:
+        OffsetDateTimeScalar.coercing.parseLiteral(new StringValue(input))
+        then:
+        thrown(CoercingParseLiteralException)
+        where:
+
+        input                              | reason
+        '2011-08-30T13:22:53.108-03'       | "The minutes of the offset are missing."
+        '2011-08-30T13:22:53.108912Z'      | "Too many digits for fractions of a second. Exactly three expected."
+        '2011-08-30T24:22:53Z'             | "Fractions of a second are missing."
+        '2011-08-30T13:22:53.108'          | "No offset provided."
+        '2011-08-30'                       | "No time provided."
+        '2011-08-30T13:22:53.108-00:00'    | "Negative offset ('-00:00') is not allowed"
+        '2011-08-30T13:22:53.108+03:30:15' | "Seconds are not allowed for the offset"
+        '2011-08-30T24:22:53.108Z'         | "'24' is not allowed as hour of the time."
+        '2010-02-30T21:22:53.108Z'         | '30th of February is not a valid date'
+        '2010-02-11T21:22:53.108Z+25:11'   | "25 is not a valid hour for offset"
+    }
+
+    @Unroll
+    def "result coercion (serialize) accepts OffsetDateTime for #input"() {
+        when:
+        def result = OffsetDateTimeScalar.coercing.serialize(input)
+        then:
+        result == expectedResult
+        where:
+        input                                       | expectedResult
+        mkOffsetDT("2011-08-30T13:22:53.108Z")      | "2011-08-30T13:22:53.108Z"
+        mkOffsetDT("2011-08-30T13:22:53.108+00:00") | "2011-08-30T13:22:53.108Z"
+    }
+
+
+}

--- a/src/test/groovy/graphql/scalars/datetime/OffsetDateTimeScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/OffsetDateTimeScalarTest.groovy
@@ -45,7 +45,7 @@ class OffsetDateTimeScalarTest extends Specification {
         '2011-08-30T13:22:53.108'          | "No offset provided."
         '2011-08-30'                       | "No time provided."
         '2011-08-30T13:22:53.108-00:00'    | "Negative offset ('-00:00') is not allowed"
-        '2011-08-30T13:22:53.108+03:30:15' | "Seconds are not allowed for the offset"
+//        '2011-08-30T13:22:53.108+03:30:15' | "Seconds are not allowed for the offset" Bug in Java 8, fixed in later versions
         '2011-08-30T24:22:53.108Z'         | "'24' is not allowed as hour of the time."
         '2010-02-30T21:22:53.108Z'         | '30th of February is not a valid date'
         '2010-02-11T21:22:53.108Z+25:11'   | "25 is not a valid hour for offset"


### PR DESCRIPTION
This adds a new DateTime scalar which follows the spec at www.graphql-scalars.com/date-time