### PR TITLE
Add two more options for returning a DateTime - Instant and Date

### DIFF
--- a/src/main/java/graphql/scalars/datetime/DateTimeScalar.java
+++ b/src/main/java/graphql/scalars/datetime/DateTimeScalar.java
@@ -8,11 +8,10 @@ import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
 
-import java.time.DateTimeException;
-import java.time.OffsetDateTime;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Date;
 import java.util.function.Function;
 
 import static graphql.scalars.util.Kit.typeName;
@@ -32,6 +31,10 @@ public class DateTimeScalar extends GraphQLScalarType {
                     offsetDateTime = (OffsetDateTime) input;
                 } else if (input instanceof ZonedDateTime) {
                     offsetDateTime = ((ZonedDateTime) input).toOffsetDateTime();
+                } else if (input instanceof Instant) {
+                    offsetDateTime = ((Instant) input).atOffset(ZoneOffset.UTC);
+                } else if (input instanceof Date) {
+                    offsetDateTime = ((Date) input).toInstant().atOffset(ZoneOffset.UTC);
                 } else if (input instanceof String) {
                     offsetDateTime = parseOffsetDateTime(input.toString(), CoercingSerializeException::new);
                 } else {

--- a/src/main/java/graphql/scalars/datetime/DateTimeScalar.java
+++ b/src/main/java/graphql/scalars/datetime/DateTimeScalar.java
@@ -33,6 +33,8 @@ public class DateTimeScalar extends GraphQLScalarType {
                     offsetDateTime = ((ZonedDateTime) input).toOffsetDateTime();
                 } else if (input instanceof Instant) {
                     offsetDateTime = ((Instant) input).atOffset(ZoneOffset.UTC);
+                } else if (input instanceof LocalDateTime) {
+                    offsetDateTime = ((LocalDateTime) input).atOffset(ZoneOffset.UTC);
                 } else if (input instanceof Date) {
                     offsetDateTime = ((Date) input).toInstant().atOffset(ZoneOffset.UTC);
                 } else if (input instanceof String) {

--- a/src/test/groovy/graphql/scalars/datetime/DateTimeScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/DateTimeScalarTest.groovy
@@ -70,6 +70,7 @@ class DateTimeScalarTest extends Specification {
         "1937-01-01T12:00:27.87+00:20"  | "1937-01-01T12:00:27.87+00:20"
         mkOffsetDT(year: 1980, hour: 3) | "1980-08-08T03:10:09+10:00"
         mkZonedDT(year: 1980, hour: 3)  | "1980-08-08T03:10:09+10:00"
+        mkLocalDT(year: 1980, hour: 3)  | "1980-08-08T03:10:09Z"
         new Instant(334588209, 0)       | "1980-08-08T13:10:09Z"
         new Date(334588209000)          | "1980-08-08T13:10:09Z"
     }
@@ -83,8 +84,7 @@ class DateTimeScalarTest extends Specification {
         where:
         input                          | expectedValue
         "1985-04-12"                   | CoercingSerializeException
-        mkLocalDT(year: 1980, hour: 3) | CoercingSerializeException
-        666                           || CoercingSerializeException
+        666                            | CoercingSerializeException
     }
 
 }

--- a/src/test/groovy/graphql/scalars/datetime/DateTimeScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/DateTimeScalarTest.groovy
@@ -5,6 +5,8 @@ import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
 import spock.lang.Unroll
+import java.util.Date
+import java.time.Instant
 
 import static graphql.scalars.util.TestKit.mkLocalDT
 import static graphql.scalars.util.TestKit.mkOffsetDT
@@ -68,6 +70,8 @@ class DateTimeScalarTest extends Specification {
         "1937-01-01T12:00:27.87+00:20"  | "1937-01-01T12:00:27.87+00:20"
         mkOffsetDT(year: 1980, hour: 3) | "1980-08-08T03:10:09+10:00"
         mkZonedDT(year: 1980, hour: 3)  | "1980-08-08T03:10:09+10:00"
+        new Instant(334588209, 0)       | "1980-08-08T13:10:09Z"
+        new Date(334588209000)          | "1980-08-08T13:10:09Z"
     }
 
     def "datetime serialisation bad inputs"() {


### PR DESCRIPTION
Provide automatic serialization for UTC timestamps returned as
either java.time.Instant or java.util.Date.