### PR TITLE
Updated Time scalar parsed value java type readme.md to java.time.OffsetTime

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ And use it in your schema
   `java.time.OffsetDateTime` objects at runtime  
 * `Time`
   * An RFC-3339 compliant time scalar that accepts string values like `16:39:57-08:00` and produces 
-  `java.time.LocalDate` objects at runtime  
+  `java.time.OffsetTime` objects at runtime  
 * `Date`
   * An RFC-3339 compliant date scalar that accepts string values like `1996-12-19` and produces 
   `java.time.LocalDate` objects at runtime  


### PR DESCRIPTION
I noticed that Readme said that Time scalar parsed value java type is java.time.LocalDate which didn't seem correct , I checked code and found that java type java.time.OffsetTime.  So, updated the documentation to increase clarity of information in Readme.md file.