### PR TITLE
Add the groovy plugin so gradle runs the tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
+    id "groovy"
 }
 
 def getDevelopmentVersion() {


### PR DESCRIPTION
The `test` task was not running the tests as it was only looking for java tests.
The plugin adds groovy as a test source directory.