### PR TITLE
Updating to graphql-java 17.x and fixing the class constructors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ import java.text.SimpleDateFormat
 
 plugins {
     id 'java'
+    id 'groovy'
     id 'java-library'
     id 'maven'
     id 'maven-publish'
@@ -41,8 +42,9 @@ repositories {
 dependencies {
     compile "com.graphql-java:graphql-java:0.0.0-2021-06-27T12-22-33-cd2bab76"
 
-    testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'
-    testCompile 'org.codehaus.groovy:groovy-all:2.4.13'
+    testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
+    testImplementation('org.codehaus.groovy:groovy:2.5.13')
+
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 
 
 dependencies {
-    compile "com.graphql-java:graphql-java:16.1"
+    compile "com.graphql-java:graphql-java:0.0.0-2021-06-27T12-22-33-cd2bab76"
 
     testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'
     testCompile 'org.codehaus.groovy:groovy-all:2.4.13'

--- a/src/main/java/graphql/scalars/ExtendedScalars.java
+++ b/src/main/java/graphql/scalars/ExtendedScalars.java
@@ -177,6 +177,8 @@ public class ExtendedScalars {
      * The scalar converts any passed in objects to Strings first and them matches it against the provided
      * scalars to ensure its an acceptable value.
      *
+     * @param name the name of the scalar
+     *
      * @return a builder of a regex scalar
      */
     public static RegexScalar.Builder newRegexScalar(String name) {
@@ -188,7 +190,6 @@ public class ExtendedScalars {
      * <p>
      * For example you may take a `String` scalar and alias it as `SocialMediaLink` if that helps introduce
      * more semantic meaning to your type system.
-     * <p>
      * <pre>
      * {@code
      *
@@ -200,6 +201,8 @@ public class ExtendedScalars {
      * </pre>
      * <p>
      * A future version of the graphql specification may add this capability but in the meantime you can use this facility.
+     *
+     * @param name the name of the aliased scalar
      *
      * @return a builder of a aliased scalar
      */

--- a/src/main/java/graphql/scalars/ExtendedScalars.java
+++ b/src/main/java/graphql/scalars/ExtendedScalars.java
@@ -39,7 +39,7 @@ public class ExtendedScalars {
      * @see java.time.OffsetDateTime
      * @see java.time.ZonedDateTime
      */
-    public static GraphQLScalarType DateTime = new DateTimeScalar();
+    public static GraphQLScalarType DateTime = DateTimeScalar.INSTANCE;
 
     /**
      * An RFC-3339 compliant date scalar that accepts string values like `1996-12-19` and produces
@@ -52,7 +52,7 @@ public class ExtendedScalars {
      *
      * @see java.time.LocalDate
      */
-    public static GraphQLScalarType Date = new DateScalar();
+    public static GraphQLScalarType Date = DateScalar.INSTANCE;
     /**
      * An RFC-3339 compliant time scalar that accepts string values like `6:39:57-08:00` and produces
      * `java.time.OffsetTime` objects at runtime.
@@ -64,7 +64,7 @@ public class ExtendedScalars {
      *
      * @see java.time.OffsetTime
      */
-    public static GraphQLScalarType Time = new TimeScalar();
+    public static GraphQLScalarType Time = TimeScalar.INSTANCE;
 
     /**
      * An object scalar allows you to have a multi level data value without defining it in the graphql schema.
@@ -89,7 +89,7 @@ public class ExtendedScalars {
      *
      * @see #Json
      */
-    public static GraphQLScalarType Object = new ObjectScalar();
+    public static GraphQLScalarType Object = ObjectScalar.INSTANCE;
 
     /**
      * A synonym class for the {@link #Object} scalar, since some people prefer their SDL to look like the following :
@@ -106,68 +106,68 @@ public class ExtendedScalars {
      *
      * @see graphql.scalars.ExtendedScalars#Object
      */
-    public static GraphQLScalarType Json = new JsonScalar();
+    public static GraphQLScalarType Json = JsonScalar.INSTANCE;
 
     /**
      * A URL scalar that accepts URL strings and produces {@link java.net.URL} objects at runtime
      */
-    public static GraphQLScalarType Url = new UrlScalar();
+    public static GraphQLScalarType Url = UrlScalar.INSTANCE;
 
     /**
      * A Locale scalar that accepts a IETF BCP 47 language tag string and produces {@link
      * java.util.Locale} objects at runtime.
      */
-    public static GraphQLScalarType Locale = new LocaleScalar();
+    public static GraphQLScalarType Locale = LocaleScalar.INSTANCE;
 
     /**
      * An `Int` scalar that MUST be greater than zero
      *
      * @see graphql.Scalars#GraphQLInt
      */
-    public static GraphQLScalarType PositiveInt = new PositiveIntScalar();
+    public static GraphQLScalarType PositiveInt = PositiveIntScalar.INSTANCE;
     /**
      * An `Int` scalar that MUST be less than zero
      *
      * @see graphql.Scalars#GraphQLInt
      */
-    public static GraphQLScalarType NegativeInt = new NegativeIntScalar();
+    public static GraphQLScalarType NegativeInt = NegativeIntScalar.INSTANCE;
     /**
      * An `Int` scalar that MUST be less than or equal to zero
      *
      * @see graphql.Scalars#GraphQLInt
      */
-    public static GraphQLScalarType NonPositiveInt = new NonPositiveIntScalar();
+    public static GraphQLScalarType NonPositiveInt = NonPositiveIntScalar.INSTANCE;
     /**
      * An `Int` scalar that MUST be greater than or equal to zero
      *
      * @see graphql.Scalars#GraphQLInt
      */
-    public static GraphQLScalarType NonNegativeInt = new NonNegativeIntScalar();
+    public static GraphQLScalarType NonNegativeInt = NonNegativeIntScalar.INSTANCE;
 
     /**
      * An `Float` scalar that MUST be greater than zero
      *
      * @see graphql.Scalars#GraphQLFloat
      */
-    public static GraphQLScalarType PositiveFloat = new PositiveFloatScalar();
+    public static GraphQLScalarType PositiveFloat = PositiveFloatScalar.INSTANCE;
     /**
      * An `Float` scalar that MUST be less than zero
      *
      * @see graphql.Scalars#GraphQLFloat
      */
-    public static GraphQLScalarType NegativeFloat = new NegativeFloatScalar();
+    public static GraphQLScalarType NegativeFloat = NegativeFloatScalar.INSTANCE;
     /**
      * An `Float` scalar that MUST be less than or equal to zero
      *
      * @see graphql.Scalars#GraphQLFloat
      */
-    public static GraphQLScalarType NonPositiveFloat = new NonPositiveFloatScalar();
+    public static GraphQLScalarType NonPositiveFloat = NonPositiveFloatScalar.INSTANCE;
     /**
      * An `Float` scalar that MUST be greater than or equal to zero
      *
      * @see graphql.Scalars#GraphQLFloat
      */
-    public static GraphQLScalarType NonNegativeFloat = new NonNegativeFloatScalar();
+    public static GraphQLScalarType NonNegativeFloat = NonNegativeFloatScalar.INSTANCE;
 
 
     /**

--- a/src/main/java/graphql/scalars/alias/AliasedScalar.java
+++ b/src/main/java/graphql/scalars/alias/AliasedScalar.java
@@ -91,11 +91,12 @@ public class AliasedScalar {
 
             @Override
             public Object parseLiteral(Object input, Map<String, Object> variables) throws CoercingParseLiteralException {
-                return aliasedScalar.getCoercing().parseLiteral(input, variables);
+                Coercing<?, ?> c = aliasedScalar.getCoercing();
+                return c.parseLiteral(input, variables);
             }
 
             @Override
-            public Value valueToLiteral(Object input) {
+            public Value<?> valueToLiteral(Object input) {
                 return aliasedScalar.getCoercing().valueToLiteral(input);
             }
         };

--- a/src/main/java/graphql/scalars/alias/AliasedScalar.java
+++ b/src/main/java/graphql/scalars/alias/AliasedScalar.java
@@ -2,6 +2,7 @@ package graphql.scalars.alias;
 
 import graphql.Assert;
 import graphql.Internal;
+import graphql.language.Value;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
@@ -14,7 +15,7 @@ import java.util.Map;
  * Access this via {@link graphql.scalars.ExtendedScalars#newAliasedScalar(String)}
  */
 @Internal
-public class AliasedScalar extends GraphQLScalarType {
+public class AliasedScalar {
 
     /**
      * A builder for {@link graphql.scalars.alias.AliasedScalar}
@@ -63,20 +64,16 @@ public class AliasedScalar extends GraphQLScalarType {
         /**
          * @return the built {@link AliasedScalar}
          */
-        public AliasedScalar build() {
+        public GraphQLScalarType build() {
             Assert.assertNotNull(name);
             return aliasedScalarImpl(name, description, aliasedScalar);
         }
     }
 
 
-    private AliasedScalar(String name, String description, Coercing coercing) {
-        super(name, description, coercing);
-    }
-
-    private static AliasedScalar aliasedScalarImpl(String name, String description, GraphQLScalarType aliasedScalar) {
+    private static GraphQLScalarType aliasedScalarImpl(String name, String description, GraphQLScalarType aliasedScalar) {
         Assert.assertNotNull(aliasedScalar);
-        return new AliasedScalar(name, description, new Coercing<Object, Object>() {
+        Coercing<Object, Object> coercing = new Coercing<Object, Object>() {
             @Override
             public Object serialize(Object input) throws CoercingSerializeException {
                 return aliasedScalar.getCoercing().serialize(input);
@@ -96,6 +93,16 @@ public class AliasedScalar extends GraphQLScalarType {
             public Object parseLiteral(Object input, Map<String, Object> variables) throws CoercingParseLiteralException {
                 return aliasedScalar.getCoercing().parseLiteral(input, variables);
             }
-        });
+
+            @Override
+            public Value valueToLiteral(Object input) {
+                return aliasedScalar.getCoercing().valueToLiteral(input);
+            }
+        };
+        return GraphQLScalarType.newScalar()
+                .name(name)
+                .description(description)
+                .coercing(coercing)
+                .build();
     }
 }

--- a/src/main/java/graphql/scalars/datetime/DateScalar.java
+++ b/src/main/java/graphql/scalars/datetime/DateScalar.java
@@ -21,12 +21,14 @@ import static graphql.scalars.util.Kit.typeName;
  * Access this via {@link graphql.scalars.ExtendedScalars#Date}
  */
 @Internal
-public class DateScalar extends GraphQLScalarType {
+public class DateScalar  {
 
     private final static DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
-    public DateScalar() {
-        super("Date", "An RFC-3339 compliant Full Date Scalar", new Coercing<LocalDate, String>() {
+    public static GraphQLScalarType INSTANCE;
+
+    static {
+        Coercing<LocalDate, String> coercing = new Coercing<LocalDate, String>() {
             @Override
             public String serialize(Object input) throws CoercingSerializeException {
                 TemporalAccessor temporalAccessor;
@@ -87,7 +89,12 @@ public class DateScalar extends GraphQLScalarType {
                     throw exceptionMaker.apply("Invalid RFC3339 full date value : '" + s + "'. because of : '" + e.getMessage() + "'");
                 }
             }
-        });
-    }
+        };
 
+        INSTANCE = GraphQLScalarType.newScalar()
+                .name("Date")
+                .description("An RFC-3339 compliant Full Date Scalar")
+                .coercing(coercing)
+                .build();
+    }
 }

--- a/src/main/java/graphql/scalars/datetime/DateScalar.java
+++ b/src/main/java/graphql/scalars/datetime/DateScalar.java
@@ -2,6 +2,7 @@ package graphql.scalars.datetime;
 
 import graphql.Internal;
 import graphql.language.StringValue;
+import graphql.language.Value;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
@@ -79,6 +80,12 @@ public class DateScalar  {
                     );
                 }
                 return parseLocalDate(((StringValue) input).getValue(), CoercingParseLiteralException::new);
+            }
+
+            @Override
+            public Value<?> valueToLiteral(Object input) {
+                String s = serialize(input);
+                return StringValue.newStringValue(s).build();
             }
 
             private LocalDate parseLocalDate(String s, Function<String, RuntimeException> exceptionMaker) {

--- a/src/main/java/graphql/scalars/datetime/DateTimeScalar.java
+++ b/src/main/java/graphql/scalars/datetime/DateTimeScalar.java
@@ -2,6 +2,7 @@ package graphql.scalars.datetime;
 
 import graphql.Internal;
 import graphql.language.StringValue;
+import graphql.language.Value;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
@@ -75,6 +76,12 @@ public class DateTimeScalar {
                     );
                 }
                 return parseOffsetDateTime(((StringValue) input).getValue(), CoercingParseLiteralException::new);
+            }
+
+            @Override
+            public Value<?> valueToLiteral(Object input) {
+                String s = serialize(input);
+                return StringValue.newStringValue(s).build();
             }
 
             private OffsetDateTime parseOffsetDateTime(String s, Function<String, RuntimeException> exceptionMaker) {

--- a/src/main/java/graphql/scalars/datetime/DateTimeScalar.java
+++ b/src/main/java/graphql/scalars/datetime/DateTimeScalar.java
@@ -21,10 +21,12 @@ import static graphql.scalars.util.Kit.typeName;
  * Access this via {@link graphql.scalars.ExtendedScalars#DateTime}
  */
 @Internal
-public class DateTimeScalar extends GraphQLScalarType {
+public class DateTimeScalar {
 
-    public DateTimeScalar() {
-        super("DateTime", "An RFC-3339 compliant DateTime Scalar", new Coercing<OffsetDateTime, String>() {
+    public static GraphQLScalarType INSTANCE;
+
+    static {
+        Coercing<OffsetDateTime, String> coercing = new Coercing<OffsetDateTime, String>() {
             @Override
             public String serialize(Object input) throws CoercingSerializeException {
                 OffsetDateTime offsetDateTime;
@@ -82,7 +84,13 @@ public class DateTimeScalar extends GraphQLScalarType {
                     throw exceptionMaker.apply("Invalid RFC3339 value : '" + s + "'. because of : '" + e.getMessage() + "'");
                 }
             }
-        });
+        };
+
+        INSTANCE = GraphQLScalarType.newScalar()
+                .name("DateTime")
+                .description("An RFC-3339 compliant DateTime Scalar")
+                .coercing(coercing)
+                .build();
     }
 
 }

--- a/src/main/java/graphql/scalars/datetime/TimeScalar.java
+++ b/src/main/java/graphql/scalars/datetime/TimeScalar.java
@@ -2,6 +2,7 @@ package graphql.scalars.datetime;
 
 import graphql.Internal;
 import graphql.language.StringValue;
+import graphql.language.Value;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
@@ -79,6 +80,12 @@ public class TimeScalar {
                     );
                 }
                 return parseOffsetTime(((StringValue) input).getValue(), CoercingParseLiteralException::new);
+            }
+
+            @Override
+            public Value<?> valueToLiteral(Object input) {
+                String s = serialize(input);
+                return StringValue.newStringValue(s).build();
             }
 
             private OffsetTime parseOffsetTime(String s, Function<String, RuntimeException> exceptionMaker) {

--- a/src/main/java/graphql/scalars/datetime/TimeScalar.java
+++ b/src/main/java/graphql/scalars/datetime/TimeScalar.java
@@ -21,12 +21,14 @@ import static graphql.scalars.util.Kit.typeName;
  * Access this via {@link graphql.scalars.ExtendedScalars#Time}
  */
 @Internal
-public class TimeScalar extends GraphQLScalarType {
+public class TimeScalar {
 
     private final static DateTimeFormatter dateFormatter = DateTimeFormatter.ISO_OFFSET_TIME;
 
-    public TimeScalar() {
-        super("Time", "An RFC-3339 compliant Full Time Scalar", new Coercing<OffsetTime, String>() {
+    public static GraphQLScalarType INSTANCE;
+
+    static {
+        Coercing<OffsetTime, String> coercing = new Coercing<OffsetTime, String>() {
             @Override
             public String serialize(Object input) throws CoercingSerializeException {
                 TemporalAccessor temporalAccessor;
@@ -87,7 +89,13 @@ public class TimeScalar extends GraphQLScalarType {
                     throw exceptionMaker.apply("Invalid RFC3339 full time value : '" + s + "'. because of : '" + e.getMessage() + "'");
                 }
             }
-        });
+        };
+
+        INSTANCE = GraphQLScalarType.newScalar()
+                .name("Time")
+                .description("An RFC-3339 compliant Full Time Scalar")
+                .coercing(coercing)
+                .build();
     }
 
 }

--- a/src/main/java/graphql/scalars/java/JavaPrimitives.java
+++ b/src/main/java/graphql/scalars/java/JavaPrimitives.java
@@ -4,6 +4,7 @@ import graphql.Internal;
 import graphql.language.FloatValue;
 import graphql.language.IntValue;
 import graphql.language.StringValue;
+import graphql.language.Value;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
@@ -12,6 +13,7 @@ import graphql.schema.GraphQLScalarType;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Objects;
 
 /**
  * Access these via {@link graphql.scalars.ExtendedScalars}
@@ -112,6 +114,12 @@ public class JavaPrimitives {
                         "Expected AST type 'IntValue' or 'StringValue' but was '" + typeName(input) + "'."
                 );
             }
+
+            @Override
+            public Value<?> valueToLiteral(Object input) {
+                Long result = Objects.requireNonNull(convertImpl(input));
+                return IntValue.newIntValue(BigInteger.valueOf(result)).build();
+            }
         };
 
         GraphQLLong = GraphQLScalarType.newScalar()
@@ -185,6 +193,12 @@ public class JavaPrimitives {
                 }
                 return value.shortValue();
             }
+
+            @Override
+            public Value<?> valueToLiteral(Object input) {
+                Short result = Objects.requireNonNull(convertImpl(input));
+                return IntValue.newIntValue(BigInteger.valueOf(result)).build();
+            }
         };
 
         GraphQLShort = GraphQLScalarType.newScalar()
@@ -257,6 +271,12 @@ public class JavaPrimitives {
                     );
                 }
                 return value.byteValue();
+            }
+
+            @Override
+            public Value<?> valueToLiteral(Object input) {
+                Byte result = Objects.requireNonNull(convertImpl(input));
+                return IntValue.newIntValue(BigInteger.valueOf(result)).build();
             }
         };
 
@@ -339,6 +359,12 @@ public class JavaPrimitives {
                         "Expected AST type 'IntValue', 'StringValue' or 'FloatValue' but was '" + typeName(input) + "'."
                 );
             }
+
+            @Override
+            public Value<?> valueToLiteral(Object input) {
+                BigInteger result = Objects.requireNonNull(convertImpl(input));
+                return IntValue.newIntValue(result).build();
+            }
         };
 
         GraphQLBigInteger = GraphQLScalarType.newScalar()
@@ -407,6 +433,13 @@ public class JavaPrimitives {
                         "Expected AST type 'IntValue', 'StringValue' or 'FloatValue' but was '" + typeName(input) + "'."
                 );
             }
+
+            @Override
+            public Value<?> valueToLiteral(Object input) {
+                BigDecimal result = Objects.requireNonNull(convertImpl(input));
+                return FloatValue.newFloatValue(result).build();
+            }
+
         };
 
         GraphQLBigDecimal = GraphQLScalarType.newScalar()
@@ -471,6 +504,13 @@ public class JavaPrimitives {
                 }
                 return value.charAt(0);
             }
+
+            @Override
+            public Value<?> valueToLiteral(Object input) {
+                Character result = Objects.requireNonNull(convertImpl(input));
+                return StringValue.newStringValue(result.toString()).build();
+            }
+
         };
 
         GraphQLChar = GraphQLScalarType.newScalar()

--- a/src/main/java/graphql/scalars/java/JavaPrimitives.java
+++ b/src/main/java/graphql/scalars/java/JavaPrimitives.java
@@ -21,8 +21,6 @@ public class JavaPrimitives {
 
     private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
     private static final BigInteger LONG_MIN = BigInteger.valueOf(Long.MIN_VALUE);
-    private static final BigInteger INT_MAX = BigInteger.valueOf(Integer.MAX_VALUE);
-    private static final BigInteger INT_MIN = BigInteger.valueOf(Integer.MIN_VALUE);
     private static final BigInteger BYTE_MAX = BigInteger.valueOf(Byte.MAX_VALUE);
     private static final BigInteger BYTE_MIN = BigInteger.valueOf(Byte.MIN_VALUE);
     private static final BigInteger SHORT_MAX = BigInteger.valueOf(Short.MAX_VALUE);
@@ -43,392 +41,440 @@ public class JavaPrimitives {
     /**
      * This represents the "Long" type which is a representation of java.lang.Long
      */
-    public static final GraphQLScalarType GraphQLLong = new GraphQLScalarType("Long", "Long type", new Coercing<Long, Long>() {
+    public static final GraphQLScalarType GraphQLLong;
 
-        private Long convertImpl(Object input) {
-            if (input instanceof Long) {
-                return (Long) input;
-            } else if (isNumberIsh(input)) {
-                BigDecimal value;
-                try {
-                    value = new BigDecimal(input.toString());
-                } catch (NumberFormatException e) {
+    static {
+        Coercing<Long, Long> longCoercing = new Coercing<Long, Long>() {
+
+            private Long convertImpl(Object input) {
+                if (input instanceof Long) {
+                    return (Long) input;
+                } else if (isNumberIsh(input)) {
+                    BigDecimal value;
+                    try {
+                        value = new BigDecimal(input.toString());
+                    } catch (NumberFormatException e) {
+                        return null;
+                    }
+                    try {
+                        return value.longValueExact();
+                    } catch (ArithmeticException e) {
+                        return null;
+                    }
+                } else {
                     return null;
                 }
-                try {
-                    return value.longValueExact();
-                } catch (ArithmeticException e) {
-                    return null;
-                }
-            } else {
-                return null;
+
             }
 
-        }
-
-        @Override
-        public Long serialize(Object input) {
-            Long result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingSerializeException(
-                        "Expected type 'Long' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public Long parseValue(Object input) {
-            Long result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingParseValueException(
-                        "Expected type 'Long' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public Long parseLiteral(Object input) {
-            if (input instanceof StringValue) {
-                try {
-                    return Long.parseLong(((StringValue) input).getValue());
-                } catch (NumberFormatException e) {
-                    throw new CoercingParseLiteralException(
-                            "Expected value to be a Long but it was '" + String.valueOf(input) + "'"
+            @Override
+            public Long serialize(Object input) {
+                Long result = convertImpl(input);
+                if (result == null) {
+                    throw new CoercingSerializeException(
+                            "Expected type 'Long' but was '" + typeName(input) + "'."
                     );
                 }
-            } else if (input instanceof IntValue) {
-                BigInteger value = ((IntValue) input).getValue();
-                if (value.compareTo(LONG_MIN) < 0 || value.compareTo(LONG_MAX) > 0) {
-                    throw new CoercingParseLiteralException(
-                            "Expected value to be in the Long range but it was '" + value.toString() + "'"
+                return result;
+            }
+
+            @Override
+            public Long parseValue(Object input) {
+                Long result = convertImpl(input);
+                if (result == null) {
+                    throw new CoercingParseValueException(
+                            "Expected type 'Long' but was '" + typeName(input) + "'."
                     );
                 }
-                return value.longValue();
+                return result;
             }
-            throw new CoercingParseLiteralException(
-                    "Expected AST type 'IntValue' or 'StringValue' but was '" + typeName(input) + "'."
-            );
-        }
-    });
+
+            @Override
+            public Long parseLiteral(Object input) {
+                if (input instanceof StringValue) {
+                    try {
+                        return Long.parseLong(((StringValue) input).getValue());
+                    } catch (NumberFormatException e) {
+                        throw new CoercingParseLiteralException(
+                                "Expected value to be a Long but it was '" + input + "'"
+                        );
+                    }
+                } else if (input instanceof IntValue) {
+                    BigInteger value = ((IntValue) input).getValue();
+                    if (value.compareTo(LONG_MIN) < 0 || value.compareTo(LONG_MAX) > 0) {
+                        throw new CoercingParseLiteralException(
+                                "Expected value to be in the Long range but it was '" + value + "'"
+                        );
+                    }
+                    return value.longValue();
+                }
+                throw new CoercingParseLiteralException(
+                        "Expected AST type 'IntValue' or 'StringValue' but was '" + typeName(input) + "'."
+                );
+            }
+        };
+
+        GraphQLLong = GraphQLScalarType.newScalar()
+                .name("Long").description("Long type")
+                .coercing(longCoercing).build();
+    }
 
     /**
      * This represents the "Short" type which is a representation of java.lang.Short
      */
-    public static final GraphQLScalarType GraphQLShort = new GraphQLScalarType("Short", "Short as Int", new Coercing<Short, Short>() {
+    public static final GraphQLScalarType GraphQLShort;
 
-        private Short convertImpl(Object input) {
-            if (input instanceof Short) {
-                return (Short) input;
-            } else if (isNumberIsh(input)) {
-                BigDecimal value;
-                try {
-                    value = new BigDecimal(input.toString());
-                } catch (NumberFormatException e) {
+    static {
+        Coercing<Short, Short> shortCoercing = new Coercing<Short, Short>() {
+
+            private Short convertImpl(Object input) {
+                if (input instanceof Short) {
+                    return (Short) input;
+                } else if (isNumberIsh(input)) {
+                    BigDecimal value;
+                    try {
+                        value = new BigDecimal(input.toString());
+                    } catch (NumberFormatException e) {
+                        return null;
+                    }
+                    try {
+                        return value.shortValueExact();
+                    } catch (ArithmeticException e) {
+                        return null;
+                    }
+                } else {
                     return null;
                 }
-                try {
-                    return value.shortValueExact();
-                } catch (ArithmeticException e) {
-                    return null;
+
+            }
+
+            @Override
+            public Short serialize(Object input) {
+                Short result = convertImpl(input);
+                if (result == null) {
+                    throw new CoercingSerializeException(
+                            "Expected type 'Short' but was '" + typeName(input) + "'."
+                    );
                 }
-            } else {
-                return null;
+                return result;
             }
 
-        }
+            @Override
+            public Short parseValue(Object input) {
+                Short result = convertImpl(input);
+                if (result == null) {
+                    throw new CoercingParseValueException(
+                            "Expected type 'Short' but was '" + typeName(input) + "'."
+                    );
+                }
+                return result;
+            }
 
-        @Override
-        public Short serialize(Object input) {
-            Short result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingSerializeException(
-                        "Expected type 'Short' but was '" + typeName(input) + "'."
-                );
+            @Override
+            public Short parseLiteral(Object input) {
+                if (!(input instanceof IntValue)) {
+                    throw new CoercingParseLiteralException(
+                            "Expected AST type 'IntValue' but was '" + typeName(input) + "'."
+                    );
+                }
+                BigInteger value = ((IntValue) input).getValue();
+                if (value.compareTo(SHORT_MIN) < 0 || value.compareTo(SHORT_MAX) > 0) {
+                    throw new CoercingParseLiteralException(
+                            "Expected value to be in the Short range but it was '" + value + "'"
+                    );
+                }
+                return value.shortValue();
             }
-            return result;
-        }
+        };
 
-        @Override
-        public Short parseValue(Object input) {
-            Short result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingParseValueException(
-                        "Expected type 'Short' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public Short parseLiteral(Object input) {
-            if (!(input instanceof IntValue)) {
-                throw new CoercingParseLiteralException(
-                        "Expected AST type 'IntValue' but was '" + typeName(input) + "'."
-                );
-            }
-            BigInteger value = ((IntValue) input).getValue();
-            if (value.compareTo(SHORT_MIN) < 0 || value.compareTo(SHORT_MAX) > 0) {
-                throw new CoercingParseLiteralException(
-                        "Expected value to be in the Short range but it was '" + value.toString() + "'"
-                );
-            }
-            return value.shortValue();
-        }
-    });
+        GraphQLShort = GraphQLScalarType.newScalar()
+                .name("Short").description("Short as Int")
+                .coercing(shortCoercing).build();
+    }
 
     /**
      * This represents the "Byte" type which is a representation of java.lang.Byte
      */
-    public static final GraphQLScalarType GraphQLByte = new GraphQLScalarType("Byte", "Byte as Int", new Coercing<Byte, Byte>() {
+    public static final GraphQLScalarType GraphQLByte;
 
-        private Byte convertImpl(Object input) {
-            if (input instanceof Byte) {
-                return (Byte) input;
-            } else if (isNumberIsh(input)) {
-                BigDecimal value;
-                try {
-                    value = new BigDecimal(input.toString());
-                } catch (NumberFormatException e) {
+    static {
+        Coercing<Byte, Byte> byteCoercing = new Coercing<Byte, Byte>() {
+
+            private Byte convertImpl(Object input) {
+                if (input instanceof Byte) {
+                    return (Byte) input;
+                } else if (isNumberIsh(input)) {
+                    BigDecimal value;
+                    try {
+                        value = new BigDecimal(input.toString());
+                    } catch (NumberFormatException e) {
+                        return null;
+                    }
+                    try {
+                        return value.byteValueExact();
+                    } catch (ArithmeticException e) {
+                        return null;
+                    }
+                } else {
                     return null;
                 }
-                try {
-                    return value.byteValueExact();
-                } catch (ArithmeticException e) {
-                    return null;
+
+            }
+
+            @Override
+            public Byte serialize(Object input) {
+                Byte result = convertImpl(input);
+                if (result == null) {
+                    throw new CoercingSerializeException(
+                            "Expected type 'Byte' but was '" + typeName(input) + "'."
+                    );
                 }
-            } else {
-                return null;
+                return result;
             }
 
-        }
+            @Override
+            public Byte parseValue(Object input) {
+                Byte result = convertImpl(input);
+                if (result == null) {
+                    throw new CoercingParseValueException(
+                            "Expected type 'Byte' but was '" + typeName(input) + "'."
+                    );
+                }
+                return result;
+            }
 
-        @Override
-        public Byte serialize(Object input) {
-            Byte result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingSerializeException(
-                        "Expected type 'Byte' but was '" + typeName(input) + "'."
-                );
+            @Override
+            public Byte parseLiteral(Object input) {
+                if (!(input instanceof IntValue)) {
+                    throw new CoercingParseLiteralException(
+                            "Expected AST type 'IntValue' but was '" + typeName(input) + "'."
+                    );
+                }
+                BigInteger value = ((IntValue) input).getValue();
+                if (value.compareTo(BYTE_MIN) < 0 || value.compareTo(BYTE_MAX) > 0) {
+                    throw new CoercingParseLiteralException(
+                            "Expected value to be in the Byte range but it was '" + value + "'"
+                    );
+                }
+                return value.byteValue();
             }
-            return result;
-        }
+        };
 
-        @Override
-        public Byte parseValue(Object input) {
-            Byte result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingParseValueException(
-                        "Expected type 'Byte' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public Byte parseLiteral(Object input) {
-            if (!(input instanceof IntValue)) {
-                throw new CoercingParseLiteralException(
-                        "Expected AST type 'IntValue' but was '" + typeName(input) + "'."
-                );
-            }
-            BigInteger value = ((IntValue) input).getValue();
-            if (value.compareTo(BYTE_MIN) < 0 || value.compareTo(BYTE_MAX) > 0) {
-                throw new CoercingParseLiteralException(
-                        "Expected value to be in the Byte range but it was '" + value.toString() + "'"
-                );
-            }
-            return value.byteValue();
-        }
-    });
+        GraphQLByte = GraphQLScalarType.newScalar()
+                .name("Byte").description("Byte as Int")
+                .coercing(byteCoercing).build();
+    }
 
 
     /**
      * This represents the "BigInteger" type which is a representation of java.math.BigInteger
      */
-    public static final GraphQLScalarType GraphQLBigInteger = new GraphQLScalarType("BigInteger", "java.math.BigInteger", new Coercing<BigInteger, BigInteger>() {
+    public static final GraphQLScalarType GraphQLBigInteger;
 
-        private BigInteger convertImpl(Object input) {
-            if (isNumberIsh(input)) {
-                BigDecimal value;
-                try {
-                    value = new BigDecimal(input.toString());
-                } catch (NumberFormatException e) {
-                    return null;
+    static {
+        Coercing<BigInteger, BigInteger> bigIntCoercing = new Coercing<BigInteger, BigInteger>() {
+
+            private BigInteger convertImpl(Object input) {
+                if (isNumberIsh(input)) {
+                    BigDecimal value;
+                    try {
+                        value = new BigDecimal(input.toString());
+                    } catch (NumberFormatException e) {
+                        return null;
+                    }
+                    try {
+                        return value.toBigIntegerExact();
+                    } catch (ArithmeticException e) {
+                        return null;
+                    }
                 }
-                try {
-                    return value.toBigIntegerExact();
-                } catch (ArithmeticException e) {
-                    return null;
-                }
+                return null;
+
             }
-            return null;
 
-        }
-
-        @Override
-        public BigInteger serialize(Object input) {
-            BigInteger result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingSerializeException(
-                        "Expected type 'BigInteger' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public BigInteger parseValue(Object input) {
-            BigInteger result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingParseValueException(
-                        "Expected type 'BigInteger' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public BigInteger parseLiteral(Object input) {
-            if (input instanceof StringValue) {
-                try {
-                    return new BigDecimal(((StringValue) input).getValue()).toBigIntegerExact();
-                } catch (NumberFormatException | ArithmeticException e) {
-                    throw new CoercingParseLiteralException(
-                            "Unable to turn AST input into a 'BigInteger' : '" + String.valueOf(input) + "'"
+            @Override
+            public BigInteger serialize(Object input) {
+                BigInteger result = convertImpl(input);
+                if (result == null) {
+                    throw new CoercingSerializeException(
+                            "Expected type 'BigInteger' but was '" + typeName(input) + "'."
                     );
                 }
-            } else if (input instanceof IntValue) {
-                return ((IntValue) input).getValue();
-            } else if (input instanceof FloatValue) {
-                try {
-                    return ((FloatValue) input).getValue().toBigIntegerExact();
-                } catch (ArithmeticException e) {
-                    throw new CoercingParseLiteralException(
-                            "Unable to turn AST input into a 'BigInteger' : '" + String.valueOf(input) + "'"
+                return result;
+            }
+
+            @Override
+            public BigInteger parseValue(Object input) {
+                BigInteger result = convertImpl(input);
+                if (result == null) {
+                    throw new CoercingParseValueException(
+                            "Expected type 'BigInteger' but was '" + typeName(input) + "'."
                     );
                 }
+                return result;
             }
-            throw new CoercingParseLiteralException(
-                    "Expected AST type 'IntValue', 'StringValue' or 'FloatValue' but was '" + typeName(input) + "'."
-            );
-        }
-    });
+
+            @Override
+            public BigInteger parseLiteral(Object input) {
+                if (input instanceof StringValue) {
+                    try {
+                        return new BigDecimal(((StringValue) input).getValue()).toBigIntegerExact();
+                    } catch (NumberFormatException | ArithmeticException e) {
+                        throw new CoercingParseLiteralException(
+                                "Unable to turn AST input into a 'BigInteger' : '" + input + "'"
+                        );
+                    }
+                } else if (input instanceof IntValue) {
+                    return ((IntValue) input).getValue();
+                } else if (input instanceof FloatValue) {
+                    try {
+                        return ((FloatValue) input).getValue().toBigIntegerExact();
+                    } catch (ArithmeticException e) {
+                        throw new CoercingParseLiteralException(
+                                "Unable to turn AST input into a 'BigInteger' : '" + input + "'"
+                        );
+                    }
+                }
+                throw new CoercingParseLiteralException(
+                        "Expected AST type 'IntValue', 'StringValue' or 'FloatValue' but was '" + typeName(input) + "'."
+                );
+            }
+        };
+
+        GraphQLBigInteger = GraphQLScalarType.newScalar()
+                .name("BigInteger").description("java.math.BigInteger")
+                .coercing(bigIntCoercing).build();
+    }
 
     /**
      * This represents the "BigDecimal" type which is a representation of java.math.BigDecimal
      */
-    public static final GraphQLScalarType GraphQLBigDecimal = new GraphQLScalarType("BigDecimal", "java.math.BigDecimal", new Coercing<BigDecimal, BigDecimal>() {
+    public static final GraphQLScalarType GraphQLBigDecimal;
 
-        private BigDecimal convertImpl(Object input) {
-            if (isNumberIsh(input)) {
-                try {
-                    return new BigDecimal(input.toString());
-                } catch (NumberFormatException e) {
-                    return null;
+    static {
+        Coercing<BigDecimal, BigDecimal> bigDecimalCoercing = new Coercing<BigDecimal, BigDecimal>() {
+
+            private BigDecimal convertImpl(Object input) {
+                if (isNumberIsh(input)) {
+                    try {
+                        return new BigDecimal(input.toString());
+                    } catch (NumberFormatException e) {
+                        return null;
+                    }
                 }
+                return null;
+
             }
-            return null;
 
-        }
-
-        @Override
-        public BigDecimal serialize(Object input) {
-            BigDecimal result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingSerializeException(
-                        "Expected type 'BigDecimal' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public BigDecimal parseValue(Object input) {
-            BigDecimal result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingParseValueException(
-                        "Expected type 'BigDecimal' but was '" + typeName(input) + "'."
-                );
-            }
-            return result;
-        }
-
-        @Override
-        public BigDecimal parseLiteral(Object input) {
-            if (input instanceof StringValue) {
-                try {
-                    return new BigDecimal(((StringValue) input).getValue());
-                } catch (NumberFormatException e) {
-                    throw new CoercingParseLiteralException(
-                            "Unable to turn AST input into a 'BigDecimal' : '" + String.valueOf(input) + "'"
+            @Override
+            public BigDecimal serialize(Object input) {
+                BigDecimal result = convertImpl(input);
+                if (result == null) {
+                    throw new CoercingSerializeException(
+                            "Expected type 'BigDecimal' but was '" + typeName(input) + "'."
                     );
                 }
-            } else if (input instanceof IntValue) {
-                return new BigDecimal(((IntValue) input).getValue());
-            } else if (input instanceof FloatValue) {
-                return ((FloatValue) input).getValue();
+                return result;
             }
-            throw new CoercingParseLiteralException(
-                    "Expected AST type 'IntValue', 'StringValue' or 'FloatValue' but was '" + typeName(input) + "'."
-            );
-        }
-    });
+
+            @Override
+            public BigDecimal parseValue(Object input) {
+                BigDecimal result = convertImpl(input);
+                if (result == null) {
+                    throw new CoercingParseValueException(
+                            "Expected type 'BigDecimal' but was '" + typeName(input) + "'."
+                    );
+                }
+                return result;
+            }
+
+            @Override
+            public BigDecimal parseLiteral(Object input) {
+                if (input instanceof StringValue) {
+                    try {
+                        return new BigDecimal(((StringValue) input).getValue());
+                    } catch (NumberFormatException e) {
+                        throw new CoercingParseLiteralException(
+                                "Unable to turn AST input into a 'BigDecimal' : '" + input + "'"
+                        );
+                    }
+                } else if (input instanceof IntValue) {
+                    return new BigDecimal(((IntValue) input).getValue());
+                } else if (input instanceof FloatValue) {
+                    return ((FloatValue) input).getValue();
+                }
+                throw new CoercingParseLiteralException(
+                        "Expected AST type 'IntValue', 'StringValue' or 'FloatValue' but was '" + typeName(input) + "'."
+                );
+            }
+        };
+
+        GraphQLBigDecimal = GraphQLScalarType.newScalar()
+                .name("BigDecimal").description("java.math.BigDecimal")
+                .coercing(bigDecimalCoercing).build();
+    }
 
 
     /**
      * This represents the "Char" type which is a representation of java.lang.Character
      */
-    public static final GraphQLScalarType GraphQLChar = new GraphQLScalarType("Char", "Char as Character", new Coercing<Character, Character>() {
+    public static final GraphQLScalarType GraphQLChar;
 
-        private Character convertImpl(Object input) {
-            if (input instanceof String && ((String) input).length() == 1) {
-                return ((String) input).charAt(0);
-            } else if (input instanceof Character) {
-                return (Character) input;
-            } else {
-                return null;
+    static {
+        Coercing<Character, Character> characterCoercing = new Coercing<Character, Character>() {
+
+            private Character convertImpl(Object input) {
+                if (input instanceof String && ((String) input).length() == 1) {
+                    return ((String) input).charAt(0);
+                } else if (input instanceof Character) {
+                    return (Character) input;
+                } else {
+                    return null;
+                }
+
             }
 
-        }
+            @Override
+            public Character serialize(Object input) {
+                Character result = convertImpl(input);
+                if (result == null) {
+                    throw new CoercingSerializeException(
+                            "Expected type 'Char' but was '" + typeName(input) + "'."
+                    );
+                }
+                return result;
+            }
 
-        @Override
-        public Character serialize(Object input) {
-            Character result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingSerializeException(
-                        "Expected type 'Char' but was '" + typeName(input) + "'."
-                );
+            @Override
+            public Character parseValue(Object input) {
+                Character result = convertImpl(input);
+                if (result == null) {
+                    throw new CoercingParseValueException(
+                            "Expected type 'Char' but was '" + typeName(input) + "'."
+                    );
+                }
+                return result;
             }
-            return result;
-        }
 
-        @Override
-        public Character parseValue(Object input) {
-            Character result = convertImpl(input);
-            if (result == null) {
-                throw new CoercingParseValueException(
-                        "Expected type 'Char' but was '" + typeName(input) + "'."
-                );
+            @Override
+            public Character parseLiteral(Object input) {
+                if (!(input instanceof StringValue)) {
+                    throw new CoercingParseLiteralException(
+                            "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
+                    );
+                }
+                String value = ((StringValue) input).getValue();
+                if (value.length() != 1) {
+                    throw new CoercingParseLiteralException(
+                            "Empty 'StringValue' provided."
+                    );
+                }
+                return value.charAt(0);
             }
-            return result;
-        }
+        };
 
-        @Override
-        public Character parseLiteral(Object input) {
-            if (!(input instanceof StringValue)) {
-                throw new CoercingParseLiteralException(
-                        "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
-                );
-            }
-            String value = ((StringValue) input).getValue();
-            if (value.length() != 1) {
-                throw new CoercingParseLiteralException(
-                        "Empty 'StringValue' provided."
-                );
-            }
-            return value.charAt(0);
-        }
-    });
+        GraphQLChar = GraphQLScalarType.newScalar()
+                .name("Char").description("Char as Character")
+                .coercing(characterCoercing).build();
+    }
 }

--- a/src/main/java/graphql/scalars/locale/LocaleScalar.java
+++ b/src/main/java/graphql/scalars/locale/LocaleScalar.java
@@ -2,6 +2,7 @@ package graphql.scalars.locale;
 
 import graphql.Internal;
 import graphql.language.StringValue;
+import graphql.language.Value;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
@@ -50,6 +51,8 @@ public class LocaleScalar {
                         throw new CoercingParseValueException(
                                 "Unable to parse value to 'java.util.Locale' because of: " + e.getMessage());
                     }
+                } else if (input instanceof Locale) {
+                    return (Locale) input;
                 } else {
                     throw new CoercingParseValueException(
                             "Expected a 'java.lang.String' object but was " + typeName(input));
@@ -64,6 +67,12 @@ public class LocaleScalar {
                     throw new CoercingParseLiteralException(
                             "Expected a 'java.lang.String' object but was " + typeName(input));
                 }
+            }
+
+            @Override
+            public Value<?> valueToLiteral(Object input) {
+                String s = serialize(input);
+                return StringValue.newStringValue(s).build();
             }
         };
 

--- a/src/main/java/graphql/scalars/locale/LocaleScalar.java
+++ b/src/main/java/graphql/scalars/locale/LocaleScalar.java
@@ -1,7 +1,5 @@
 package graphql.scalars.locale;
 
-import static graphql.scalars.util.Kit.typeName;
-
 import graphql.Internal;
 import graphql.language.StringValue;
 import graphql.schema.Coercing;
@@ -9,59 +7,70 @@ import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
+
 import java.util.Locale;
+
+import static graphql.scalars.util.Kit.typeName;
 
 /**
  * Access this via {@link graphql.scalars.ExtendedScalars#Locale}
  */
 @Internal
-public class LocaleScalar extends GraphQLScalarType {
+public class LocaleScalar {
 
-  public LocaleScalar() {
-    super("Locale", "A IETF BCP 47 language tag", new Coercing<Locale, String>() {
+    public static GraphQLScalarType INSTANCE;
 
-      @Override
-      public String serialize(Object input) throws CoercingSerializeException {
-        if (input instanceof String) {
-          try {
-            return Locale.forLanguageTag((String) input).toLanguageTag();
-          } catch (Exception e) {
-            throw new CoercingSerializeException(
-                "Expected a valid language tag string but was but was " + typeName(input));
-          }
-        }
-        if (input instanceof Locale) {
-          return ((Locale) input).toLanguageTag();
-        } else {
-          throw new CoercingSerializeException(
-              "Expected a 'java.util.Locale' object but was " + typeName(input));
-        }
-      }
+    static {
+        Coercing<Locale, String> coercing = new Coercing<Locale, String>() {
 
-      @Override
-      public Locale parseValue(Object input) throws CoercingParseValueException {
-        if (input instanceof String) {
-          try {
-            return Locale.forLanguageTag(input.toString());
-          } catch (Exception e) {
-            throw new CoercingParseValueException(
-                "Unable to parse value to 'java.util.Locale' because of: " + e.getMessage());
-          }
-        } else {
-          throw new CoercingParseValueException(
-              "Expected a 'java.lang.String' object but was " + typeName(input));
-        }
-      }
+            @Override
+            public String serialize(Object input) throws CoercingSerializeException {
+                if (input instanceof String) {
+                    try {
+                        return Locale.forLanguageTag((String) input).toLanguageTag();
+                    } catch (Exception e) {
+                        throw new CoercingSerializeException(
+                                "Expected a valid language tag string but was but was " + typeName(input));
+                    }
+                }
+                if (input instanceof Locale) {
+                    return ((Locale) input).toLanguageTag();
+                } else {
+                    throw new CoercingSerializeException(
+                            "Expected a 'java.util.Locale' object but was " + typeName(input));
+                }
+            }
 
-      @Override
-      public Locale parseLiteral(Object input) throws CoercingParseLiteralException {
-        if (input instanceof StringValue) {
-          return Locale.forLanguageTag(((StringValue) input).getValue());
-        } else {
-          throw new CoercingParseLiteralException(
-              "Expected a 'java.lang.String' object but was " + typeName(input));
-        }
-      }
-    });
-  }
+            @Override
+            public Locale parseValue(Object input) throws CoercingParseValueException {
+                if (input instanceof String) {
+                    try {
+                        return Locale.forLanguageTag(input.toString());
+                    } catch (Exception e) {
+                        throw new CoercingParseValueException(
+                                "Unable to parse value to 'java.util.Locale' because of: " + e.getMessage());
+                    }
+                } else {
+                    throw new CoercingParseValueException(
+                            "Expected a 'java.lang.String' object but was " + typeName(input));
+                }
+            }
+
+            @Override
+            public Locale parseLiteral(Object input) throws CoercingParseLiteralException {
+                if (input instanceof StringValue) {
+                    return Locale.forLanguageTag(((StringValue) input).getValue());
+                } else {
+                    throw new CoercingParseLiteralException(
+                            "Expected a 'java.lang.String' object but was " + typeName(input));
+                }
+            }
+        };
+
+        INSTANCE = GraphQLScalarType.newScalar()
+                .name("Locale")
+                .description("A IETF BCP 47 language tag")
+                .coercing(coercing)
+                .build();
+    }
 }

--- a/src/main/java/graphql/scalars/numeric/FloatCoercing.java
+++ b/src/main/java/graphql/scalars/numeric/FloatCoercing.java
@@ -1,6 +1,7 @@
 package graphql.scalars.numeric;
 
 import graphql.Internal;
+import graphql.language.Value;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
@@ -31,5 +32,10 @@ abstract class FloatCoercing implements Coercing<Double, Double> {
     public Double parseLiteral(Object input) throws CoercingParseLiteralException {
         Double d = (Double) GraphQLFloat.getCoercing().parseLiteral(input);
         return check(d, CoercingParseLiteralException::new);
+    }
+
+    @Override
+    public Value valueToLiteral(Object input) {
+        return GraphQLFloat.getCoercing().valueToLiteral(input);
     }
 }

--- a/src/main/java/graphql/scalars/numeric/FloatCoercing.java
+++ b/src/main/java/graphql/scalars/numeric/FloatCoercing.java
@@ -35,7 +35,7 @@ abstract class FloatCoercing implements Coercing<Double, Double> {
     }
 
     @Override
-    public Value valueToLiteral(Object input) {
+    public Value<?> valueToLiteral(Object input) {
         return GraphQLFloat.getCoercing().valueToLiteral(input);
     }
 }

--- a/src/main/java/graphql/scalars/numeric/IntCoercing.java
+++ b/src/main/java/graphql/scalars/numeric/IntCoercing.java
@@ -1,6 +1,7 @@
 package graphql.scalars.numeric;
 
 import graphql.Internal;
+import graphql.language.Value;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
@@ -32,4 +33,10 @@ abstract class IntCoercing implements Coercing<Integer, Integer> {
         Integer i = (Integer) GraphQLInt.getCoercing().parseLiteral(input);
         return check(i, CoercingParseLiteralException::new);
     }
+
+    @Override
+    public Value valueToLiteral(Object input) {
+        return GraphQLInt.getCoercing().valueToLiteral(input);
+    }
+
 }

--- a/src/main/java/graphql/scalars/numeric/IntCoercing.java
+++ b/src/main/java/graphql/scalars/numeric/IntCoercing.java
@@ -35,7 +35,7 @@ abstract class IntCoercing implements Coercing<Integer, Integer> {
     }
 
     @Override
-    public Value valueToLiteral(Object input) {
+    public Value<?> valueToLiteral(Object input) {
         return GraphQLInt.getCoercing().valueToLiteral(input);
     }
 

--- a/src/main/java/graphql/scalars/numeric/NegativeFloatScalar.java
+++ b/src/main/java/graphql/scalars/numeric/NegativeFloatScalar.java
@@ -9,16 +9,20 @@ import java.util.function.Function;
  * Access this via {@link graphql.scalars.ExtendedScalars#NegativeFloat}
  */
 @Internal
-public class NegativeFloatScalar extends GraphQLScalarType {
-    public NegativeFloatScalar() {
-        super("NegativeFloat", "An Float scalar that must be a negative value", new FloatCoercing() {
-            @Override
-            protected Double check(Double d, Function<String, RuntimeException> exceptionMaker) {
-                if (!(d < 0)) {
-                    throw exceptionMaker.apply("The value must be a negative value");
+public class NegativeFloatScalar {
+
+    public static GraphQLScalarType INSTANCE = GraphQLScalarType.newScalar()
+            .name("NegativeFloat")
+            .description("An Float scalar that must be a negative value")
+            .coercing(new FloatCoercing() {
+                @Override
+                protected Double check(Double d, Function<String, RuntimeException> exceptionMaker) {
+                    if (!(d < 0)) {
+                        throw exceptionMaker.apply("The value must be a negative value");
+                    }
+                    return d;
                 }
-                return d;
-            }
-        });
-    }
+            })
+            .build();
+
 }

--- a/src/main/java/graphql/scalars/numeric/NegativeIntScalar.java
+++ b/src/main/java/graphql/scalars/numeric/NegativeIntScalar.java
@@ -9,16 +9,20 @@ import java.util.function.Function;
  * Access this via {@link graphql.scalars.ExtendedScalars#NegativeInt}
  */
 @Internal
-public class NegativeIntScalar extends GraphQLScalarType {
-    public NegativeIntScalar() {
-        super("NegativeInt", "An Int scalar that must be a negative value", new IntCoercing() {
-            @Override
-            protected Integer check(Integer i, Function<String, RuntimeException> exceptionMaker) {
-                if (!(i < 0)) {
-                    throw exceptionMaker.apply("The value must be a negative integer");
+public class NegativeIntScalar {
+
+    public static GraphQLScalarType INSTANCE = GraphQLScalarType.newScalar()
+            .name("NegativeInt")
+            .description("An Int scalar that must be a negative value")
+            .coercing(new IntCoercing() {
+                @Override
+                protected Integer check(Integer i, Function<String, RuntimeException> exceptionMaker) {
+                    if (!(i < 0)) {
+                        throw exceptionMaker.apply("The value must be a negative integer");
+                    }
+                    return i;
                 }
-                return i;
-            }
-        });
-    }
+            })
+            .build();
+
 }

--- a/src/main/java/graphql/scalars/numeric/NonNegativeFloatScalar.java
+++ b/src/main/java/graphql/scalars/numeric/NonNegativeFloatScalar.java
@@ -9,16 +9,19 @@ import java.util.function.Function;
  * Access this via {@link graphql.scalars.ExtendedScalars#NonNegativeFloat}
  */
 @Internal
-public class NonNegativeFloatScalar extends GraphQLScalarType {
-    public NonNegativeFloatScalar() {
-        super("NonNegativeFloat", "An Float scalar that must be greater than or equal to zero", new FloatCoercing() {
-            @Override
-            protected Double check(Double d, Function<String, RuntimeException> exceptionMaker) {
-                if (!(d >= 0)) {
-                    throw exceptionMaker.apply("The value must be greater than or equal to zero");
+public class NonNegativeFloatScalar {
+
+    public static GraphQLScalarType INSTANCE = GraphQLScalarType.newScalar()
+            .name("NonNegativeFloat")
+            .description("An Float scalar that must be greater than or equal to zero")
+            .coercing(new FloatCoercing() {
+                @Override
+                protected Double check(Double d, Function<String, RuntimeException> exceptionMaker) {
+                    if (!(d >= 0)) {
+                        throw exceptionMaker.apply("The value must be greater than or equal to zero");
+                    }
+                    return d;
                 }
-                return d;
-            }
-        });
-    }
+            })
+            .build();
 }

--- a/src/main/java/graphql/scalars/numeric/NonNegativeIntScalar.java
+++ b/src/main/java/graphql/scalars/numeric/NonNegativeIntScalar.java
@@ -9,16 +9,20 @@ import java.util.function.Function;
  * Access this via {@link graphql.scalars.ExtendedScalars#NonNegativeInt}
  */
 @Internal
-public class NonNegativeIntScalar extends GraphQLScalarType {
-    public NonNegativeIntScalar() {
-        super("NonNegativeInt", "An Int scalar that must be greater than or equal to zero", new IntCoercing() {
-            @Override
-            protected Integer check(Integer i, Function<String, RuntimeException> exceptionMaker) {
-                if (!(i >= 0)) {
-                    throw exceptionMaker.apply("The value must be greater than or equal to zero");
+public class NonNegativeIntScalar {
+
+    public static GraphQLScalarType INSTANCE = GraphQLScalarType.newScalar()
+            .name("NonNegativeInt")
+            .description("An Int scalar that must be greater than or equal to zero")
+            .coercing(new IntCoercing() {
+                @Override
+                protected Integer check(Integer i, Function<String, RuntimeException> exceptionMaker) {
+                    if (!(i >= 0)) {
+                        throw exceptionMaker.apply("The value must be greater than or equal to zero");
+                    }
+                    return i;
                 }
-                return i;
-            }
-        });
-    }
+            })
+            .build();
+
 }

--- a/src/main/java/graphql/scalars/numeric/NonPositiveFloatScalar.java
+++ b/src/main/java/graphql/scalars/numeric/NonPositiveFloatScalar.java
@@ -6,19 +6,20 @@ import graphql.schema.GraphQLScalarType;
 import java.util.function.Function;
 
 /**
- * Access this via {@link graphql.scalars.ExtendedScalars#NonPositiveInt}
+ * Access this via {@link graphql.scalars.ExtendedScalars#NonPositiveFloat}
  */
 @Internal
-public class NonPositiveFloatScalar extends GraphQLScalarType {
-    public NonPositiveFloatScalar() {
-        super("NonPositiveFloat", "An Float scalar that must be less than or equal to zero", new FloatCoercing() {
-            @Override
-            protected Double check(Double d, Function<String, RuntimeException> exceptionMaker) {
-                if (!(d <= 0)) {
-                    throw exceptionMaker.apply("The value must be less than or equal to zero");
+public class NonPositiveFloatScalar {
+    public static GraphQLScalarType INSTANCE = GraphQLScalarType.newScalar()
+            .name("NonPositiveFloat").description("An Float scalar that must be less than or equal to zero")
+            .coercing(new FloatCoercing() {
+                @Override
+                protected Double check(Double d, Function<String, RuntimeException> exceptionMaker) {
+                    if (!(d <= 0)) {
+                        throw exceptionMaker.apply("The value must be less than or equal to zero");
+                    }
+                    return d;
                 }
-                return d;
-            }
-        });
-    }
+            })
+            .build();
 }

--- a/src/main/java/graphql/scalars/numeric/NonPositiveIntScalar.java
+++ b/src/main/java/graphql/scalars/numeric/NonPositiveIntScalar.java
@@ -9,16 +9,18 @@ import java.util.function.Function;
  * Access this via {@link graphql.scalars.ExtendedScalars#NonPositiveInt}
  */
 @Internal
-public class NonPositiveIntScalar extends GraphQLScalarType {
-    public NonPositiveIntScalar() {
-        super("NonPositiveInt", "An Int scalar that must be less than or equal to zero", new IntCoercing() {
-            @Override
-            protected Integer check(Integer i, Function<String, RuntimeException> exceptionMaker) {
-                if (!(i <= 0)) {
-                    throw exceptionMaker.apply("The value must be less than or equal to zero");
+public class NonPositiveIntScalar {
+    public static GraphQLScalarType INSTANCE = GraphQLScalarType.newScalar()
+            .name("NonPositiveInt")
+            .description("An Int scalar that must be less than or equal to zero")
+            .coercing(new IntCoercing() {
+                @Override
+                protected Integer check(Integer i, Function<String, RuntimeException> exceptionMaker) {
+                    if (!(i <= 0)) {
+                        throw exceptionMaker.apply("The value must be less than or equal to zero");
+                    }
+                    return i;
                 }
-                return i;
-            }
-        });
-    }
+            })
+            .build();
 }

--- a/src/main/java/graphql/scalars/numeric/PositiveFloatScalar.java
+++ b/src/main/java/graphql/scalars/numeric/PositiveFloatScalar.java
@@ -9,16 +9,18 @@ import java.util.function.Function;
  * Access this via {@link graphql.scalars.ExtendedScalars#PositiveFloat}
  */
 @Internal
-public class PositiveFloatScalar extends GraphQLScalarType {
-    public PositiveFloatScalar() {
-        super("PositiveFloat", "An Float scalar that must be a positive value", new FloatCoercing() {
-            @Override
-            protected Double check(Double d, Function<String, RuntimeException> exceptionMaker) {
-                if (!(d > 0)) {
-                    throw exceptionMaker.apply("The value must be a positive value");
+public class PositiveFloatScalar {
+    public static GraphQLScalarType INSTANCE = GraphQLScalarType.newScalar()
+            .name("PositiveFloat")
+            .description("An Float scalar that must be a positive value")
+            .coercing(new FloatCoercing() {
+                @Override
+                protected Double check(Double d, Function<String, RuntimeException> exceptionMaker) {
+                    if (!(d > 0)) {
+                        throw exceptionMaker.apply("The value must be a positive value");
+                    }
+                    return d;
                 }
-                return d;
-            }
-        });
-    }
+            })
+            .build();
 }

--- a/src/main/java/graphql/scalars/numeric/PositiveIntScalar.java
+++ b/src/main/java/graphql/scalars/numeric/PositiveIntScalar.java
@@ -9,16 +9,19 @@ import java.util.function.Function;
  * Access this via {@link graphql.scalars.ExtendedScalars#PositiveInt}
  */
 @Internal
-public class PositiveIntScalar extends GraphQLScalarType {
-    public PositiveIntScalar() {
-        super("PositiveInt", "An Int scalar that must be a positive value", new IntCoercing() {
-            @Override
-            protected Integer check(Integer i, Function<String, RuntimeException> exceptionMaker) {
-                if (!(i > 0)) {
-                    throw exceptionMaker.apply("The value must be a positive integer");
+public class PositiveIntScalar {
+
+    public static GraphQLScalarType INSTANCE = GraphQLScalarType.newScalar()
+            .name("PositiveInt")
+            .description("An Int scalar that must be a positive value")
+            .coercing(new IntCoercing() {
+                @Override
+                protected Integer check(Integer i, Function<String, RuntimeException> exceptionMaker) {
+                    if (!(i > 0)) {
+                        throw exceptionMaker.apply("The value must be a positive integer");
+                    }
+                    return i;
                 }
-                return i;
-            }
-        });
-    }
+            })
+            .build();
 }

--- a/src/main/java/graphql/scalars/object/JsonScalar.java
+++ b/src/main/java/graphql/scalars/object/JsonScalar.java
@@ -1,6 +1,9 @@
 package graphql.scalars.object;
 
 import graphql.Internal;
+import graphql.schema.GraphQLScalarType;
+
+import static graphql.scalars.object.ObjectScalar.OBJECT_COERCING;
 
 /**
  * A synonym class for {@link graphql.scalars.object.ObjectScalar}
@@ -8,8 +11,11 @@ import graphql.Internal;
  * Access this via {@link graphql.scalars.ExtendedScalars#Json}
  */
 @Internal
-public class JsonScalar extends ObjectScalar {
-    public JsonScalar() {
-        super("JSON", "A JSON scalar");
-    }
+public class JsonScalar {
+
+    public static GraphQLScalarType INSTANCE = GraphQLScalarType.newScalar()
+            .name("JSON")
+            .description("A JSON scalar")
+            .coercing(OBJECT_COERCING)
+            .build();
 }

--- a/src/main/java/graphql/scalars/object/ObjectScalar.java
+++ b/src/main/java/graphql/scalars/object/ObjectScalar.java
@@ -31,77 +31,75 @@ import static graphql.scalars.util.Kit.typeName;
  * Access this via {@link graphql.scalars.ExtendedScalars#Object}
  */
 @Internal
-public class ObjectScalar extends GraphQLScalarType {
+public class ObjectScalar {
 
+    static Coercing<Object, Object> OBJECT_COERCING = new Coercing<Object, Object>() {
+        @Override
+        public Object serialize(Object input) throws CoercingSerializeException {
+            return input;
+        }
 
-    public ObjectScalar() {
-        this("Object", "An object scalar");
-    }
+        @Override
+        public Object parseValue(Object input) throws CoercingParseValueException {
+            return input;
+        }
 
-    ObjectScalar(String name, String description) {
-        super(name, description, new Coercing<Object, Object>() {
-            @Override
-            public Object serialize(Object input) throws CoercingSerializeException {
-                return input;
+        @Override
+        public Object parseLiteral(Object input) throws CoercingParseLiteralException {
+            return parseLiteral(input, Collections.emptyMap());
+        }
+
+        @Override
+        public Object parseLiteral(Object input, Map<String, Object> variables) throws CoercingParseLiteralException {
+            if (!(input instanceof Value)) {
+                throw new CoercingParseLiteralException(
+                        "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
+                );
             }
-
-            @Override
-            public Object parseValue(Object input) throws CoercingParseValueException {
-                return input;
+            if (input instanceof NullValue) {
+                return null;
             }
-
-            @Override
-            public Object parseLiteral(Object input) throws CoercingParseLiteralException {
-                return parseLiteral(input, Collections.emptyMap());
+            if (input instanceof FloatValue) {
+                return ((FloatValue) input).getValue();
             }
-
-            @Override
-            public Object parseLiteral(Object input, Map<String, Object> variables) throws CoercingParseLiteralException {
-                if (!(input instanceof Value)) {
-                    throw new CoercingParseLiteralException(
-                            "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
-                    );
-                }
-                if (input instanceof NullValue) {
-                    return null;
-                }
-                if (input instanceof FloatValue) {
-                    return ((FloatValue) input).getValue();
-                }
-                if (input instanceof StringValue) {
-                    return ((StringValue) input).getValue();
-                }
-                if (input instanceof IntValue) {
-                    return ((IntValue) input).getValue();
-                }
-                if (input instanceof BooleanValue) {
-                    return ((BooleanValue) input).isValue();
-                }
-                if (input instanceof EnumValue) {
-                    return ((EnumValue) input).getName();
-                }
-                if (input instanceof VariableReference) {
-                    String varName = ((VariableReference) input).getName();
-                    return variables.get(varName);
-                }
-                if (input instanceof ArrayValue) {
-                    List<Value> values = ((ArrayValue) input).getValues();
-                    return values.stream()
-                            .map(v -> parseLiteral(v, variables))
-                            .collect(Collectors.toList());
-                }
-                if (input instanceof ObjectValue) {
-                    List<ObjectField> values = ((ObjectValue) input).getObjectFields();
-                    Map<String, Object> parsedValues = new LinkedHashMap<>();
-                    values.forEach(fld -> {
-                        Object parsedValue = parseLiteral(fld.getValue(), variables);
-                        parsedValues.put(fld.getName(), parsedValue);
-                    });
-                    return parsedValues;
-                }
-                return Assert.assertShouldNeverHappen("We have covered all Value types");
+            if (input instanceof StringValue) {
+                return ((StringValue) input).getValue();
             }
-        });
-    }
+            if (input instanceof IntValue) {
+                return ((IntValue) input).getValue();
+            }
+            if (input instanceof BooleanValue) {
+                return ((BooleanValue) input).isValue();
+            }
+            if (input instanceof EnumValue) {
+                return ((EnumValue) input).getName();
+            }
+            if (input instanceof VariableReference) {
+                String varName = ((VariableReference) input).getName();
+                return variables.get(varName);
+            }
+            if (input instanceof ArrayValue) {
+                List<Value> values = ((ArrayValue) input).getValues();
+                return values.stream()
+                        .map(v -> parseLiteral(v, variables))
+                        .collect(Collectors.toList());
+            }
+            if (input instanceof ObjectValue) {
+                List<ObjectField> values = ((ObjectValue) input).getObjectFields();
+                Map<String, Object> parsedValues = new LinkedHashMap<>();
+                values.forEach(fld -> {
+                    Object parsedValue = parseLiteral(fld.getValue(), variables);
+                    parsedValues.put(fld.getName(), parsedValue);
+                });
+                return parsedValues;
+            }
+            return Assert.assertShouldNeverHappen("We have covered all Value types");
+        }
+    };
 
+    public static GraphQLScalarType INSTANCE = GraphQLScalarType.newScalar()
+            .name("Object")
+            .description("An object scalar")
+            .coercing(OBJECT_COERCING)
+            .build();
 }

--- a/src/main/java/graphql/scalars/regex/RegexScalar.java
+++ b/src/main/java/graphql/scalars/regex/RegexScalar.java
@@ -23,7 +23,7 @@ import static graphql.scalars.util.Kit.typeName;
  * a regular expression.
  */
 @PublicApi
-public class RegexScalar extends GraphQLScalarType {
+public class RegexScalar {
 
     /**
      * A builder for {@link graphql.scalars.regex.RegexScalar}
@@ -84,19 +84,16 @@ public class RegexScalar extends GraphQLScalarType {
         /**
          * @return the built {@link graphql.scalars.regex.RegexScalar}
          */
-        public RegexScalar build() {
+        public GraphQLScalarType build() {
             Assert.assertNotNull(name);
             return regexScalarImpl(name, description, patterns);
         }
     }
 
-    private RegexScalar(String name, String description, Coercing coercing) {
-        super(name, description, coercing);
-    }
-
-    private static RegexScalar regexScalarImpl(String name, String description, List<Pattern> patterns) {
+    private static GraphQLScalarType regexScalarImpl(String name, String description, List<Pattern> patterns) {
         Assert.assertNotNull(patterns);
-        return new RegexScalar(name, description, new Coercing<String, String>() {
+
+        Coercing<String, String> coercing = new Coercing<String, String>() {
             @Override
             public String serialize(Object input) throws CoercingSerializeException {
                 String value = String.valueOf(input);
@@ -129,6 +126,12 @@ public class RegexScalar extends GraphQLScalarType {
                 }
                 throw exceptionMaker.apply("Unable to accept a value into the '" + name + "' scalar.  It does not match the regular expressions.");
             }
-        });
+        };
+
+        return GraphQLScalarType.newScalar()
+                .name(name)
+                .description(description)
+                .coercing(coercing)
+                .build();
     }
 }

--- a/src/main/java/graphql/scalars/regex/RegexScalar.java
+++ b/src/main/java/graphql/scalars/regex/RegexScalar.java
@@ -3,6 +3,7 @@ package graphql.scalars.regex;
 import graphql.Assert;
 import graphql.PublicApi;
 import graphql.language.StringValue;
+import graphql.language.Value;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
@@ -116,6 +117,13 @@ public class RegexScalar {
                 String value = ((StringValue) input).getValue();
                 return matches(value, CoercingParseLiteralException::new);
             }
+
+            @Override
+            public Value<?> valueToLiteral(Object input) {
+                String s = serialize(input);
+                return StringValue.newStringValue(s).build();
+            }
+
 
             private String matches(String value, Function<String, RuntimeException> exceptionMaker) {
                 for (Pattern pattern : patterns) {

--- a/src/main/java/graphql/scalars/url/UrlScalar.java
+++ b/src/main/java/graphql/scalars/url/UrlScalar.java
@@ -2,6 +2,7 @@ package graphql.scalars.url;
 
 import graphql.Internal;
 import graphql.language.StringValue;
+import graphql.language.Value;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
@@ -66,6 +67,13 @@ public class UrlScalar {
                 }
                 return parseURL(((StringValue) input).getValue(), CoercingParseLiteralException::new);
             }
+
+            @Override
+            public Value valueToLiteral(Object input) {
+                URL url = serialize(input);
+                return StringValue.newStringValue(url.toExternalForm()).build();
+            }
+
 
             private URL parseURL(String input, Function<String, RuntimeException> exceptionMaker) {
                 try {

--- a/src/main/java/graphql/scalars/url/UrlScalar.java
+++ b/src/main/java/graphql/scalars/url/UrlScalar.java
@@ -18,10 +18,12 @@ import java.util.function.Function;
 import static graphql.scalars.util.Kit.typeName;
 
 @Internal
-public class UrlScalar extends GraphQLScalarType {
+public class UrlScalar {
 
-    public UrlScalar() {
-        super("Url", "A Url scalar", new Coercing<URL, URL>() {
+    public static GraphQLScalarType INSTANCE;
+
+    static {
+        Coercing<URL, URL> coercing = new Coercing<URL, URL>() {
             @Override
             public URL serialize(Object input) throws CoercingSerializeException {
                 Optional<URL> url;
@@ -68,11 +70,17 @@ public class UrlScalar extends GraphQLScalarType {
             private URL parseURL(String input, Function<String, RuntimeException> exceptionMaker) {
                 try {
                     return new URL(input);
-                } catch (MalformedURLException e){
+                } catch (MalformedURLException e) {
                     throw exceptionMaker.apply("Invalid URL value : '" + input + "'.");
                 }
             }
-        });
+        };
+
+        INSTANCE = GraphQLScalarType.newScalar()
+                .name("Url")
+                .description("A Url scalar")
+                .coercing(coercing)
+                .build();
     }
 
     private static Optional<URL> toURL(Object input) {

--- a/src/test/groovy/graphql/scalars/alias/AliasedScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/alias/AliasedScalarTest.groovy
@@ -3,11 +3,12 @@ package graphql.scalars.alias
 import graphql.Scalars
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.schema.GraphQLScalarType
 import spock.lang.Specification
 
 class AliasedScalarTest extends Specification {
 
-    AliasedScalar socialMediaLink = ExtendedScalars.newAliasedScalar("SocialMediaLink")
+    GraphQLScalarType socialMediaLink = ExtendedScalars.newAliasedScalar("SocialMediaLink")
             .aliasedScalar(Scalars.GraphQLString)
             .build()
 

--- a/src/test/groovy/graphql/scalars/datetime/DateScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/DateScalarTest.groovy
@@ -1,16 +1,18 @@
 package graphql.scalars.datetime
 
 import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
 import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.mkLocalDate
 import static graphql.scalars.util.TestKit.mkOffsetDT
+import static graphql.scalars.util.TestKit.mkStringValue
 import static graphql.scalars.util.TestKit.mkZonedDT
 
 class DateScalarTest extends Specification {
 
-    def coercing = new DateScalar().getCoercing()
+    def coercing = ExtendedScalars.Date.getCoercing()
 
     @Unroll
     def "full date parseValue"() {
@@ -50,6 +52,20 @@ class DateScalarTest extends Specification {
         "1937-01-01"                    | "1937-01-01"
         mkOffsetDT(year: 1980, hour: 3) | "1980-08-08"
         mkZonedDT(year: 1980, hour: 3)  | "1980-08-08"
+    }
+
+    @Unroll
+    def "full date valueToLiteral"() {
+
+        when:
+        def result = coercing.valueToLiteral(input)
+        then:
+        result.isEqualTo(expectedValue)
+        where:
+        input                           | expectedValue
+        "1937-01-01"                    | mkStringValue("1937-01-01")
+        mkOffsetDT(year: 1980, hour: 3) | mkStringValue("1980-08-08")
+        mkZonedDT(year: 1980, hour: 3)  | mkStringValue("1980-08-08")
     }
 
 }

--- a/src/test/groovy/graphql/scalars/datetime/DateTimeScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/DateTimeScalarTest.groovy
@@ -1,6 +1,7 @@
 package graphql.scalars.datetime
 
 import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
@@ -8,11 +9,12 @@ import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.mkLocalDT
 import static graphql.scalars.util.TestKit.mkOffsetDT
+import static graphql.scalars.util.TestKit.mkStringValue
 import static graphql.scalars.util.TestKit.mkZonedDT
 
 class DateTimeScalarTest extends Specification {
 
-    def coercing = new DateTimeScalar().getCoercing()
+    def coercing = ExtendedScalars.DateTime.getCoercing()
 
     @Unroll
     def "datetime parseValue"() {
@@ -28,6 +30,22 @@ class DateTimeScalarTest extends Specification {
         "1937-01-01T12:00:27.87+00:20"  | mkOffsetDT("1937-01-01T12:00:27.87+00:20")
         mkOffsetDT(year: 1980, hour: 3) | mkOffsetDT("1980-08-08T03:10:09+10:00")
         mkZonedDT(year: 1980, hour: 3)  | mkOffsetDT("1980-08-08T03:10:09+10:00")
+    }
+
+    @Unroll
+    def "datetime valueToLiteral"() {
+
+        when:
+        def result = coercing.valueToLiteral(input)
+        then:
+        result.isEqualTo(expectedValue)
+        where:
+        input                           | expectedValue
+        "1985-04-12T23:20:50.52Z"       | mkStringValue("1985-04-12T23:20:50.52Z")
+        "1996-12-19T16:39:57-08:00"     | mkStringValue("1996-12-19T16:39:57-08:00")
+        "1937-01-01T12:00:27.87+00:20"  | mkStringValue("1937-01-01T12:00:27.87+00:20")
+        mkOffsetDT(year: 1980, hour: 3) | mkStringValue("1980-08-08T03:10:09+10:00")
+        mkZonedDT(year: 1980, hour: 3)  | mkStringValue("1980-08-08T03:10:09+10:00")
     }
 
     @Unroll

--- a/src/test/groovy/graphql/scalars/datetime/TimeScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/TimeScalarTest.groovy
@@ -1,6 +1,7 @@
 package graphql.scalars.datetime
 
 import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
@@ -9,11 +10,12 @@ import spock.lang.Unroll
 import static graphql.scalars.util.TestKit.mkLocalDT
 import static graphql.scalars.util.TestKit.mkOffsetDT
 import static graphql.scalars.util.TestKit.mkOffsetT
+import static graphql.scalars.util.TestKit.mkStringValue
 import static graphql.scalars.util.TestKit.mkZonedDT
 
 class TimeScalarTest extends Specification {
 
-    def coercing = new TimeScalar().getCoercing()
+    def coercing = ExtendedScalars.Time.getCoercing()
 
     @Unroll
     def "datetime parseValue"() {
@@ -69,6 +71,21 @@ class TimeScalarTest extends Specification {
         "12:00:27.87+00:20"             | "12:00:27.87+00:20"
         mkOffsetDT(year: 1980, hour: 3) | "03:10:09+10:00"
         mkZonedDT(year: 1980, hour: 3)  | "03:10:09+10:00"
+    }
+
+    def "datetime valueToLiteral"() {
+
+        when:
+        def result = coercing.valueToLiteral(input)
+        then:
+        result.isEqualTo(expectedValue)
+        where:
+        input                           | expectedValue
+        "23:20:50.52Z"                  | mkStringValue("23:20:50.52Z")
+        "16:39:57-08:00"                | mkStringValue("16:39:57-08:00")
+        "12:00:27.87+00:20"             | mkStringValue("12:00:27.87+00:20")
+        mkOffsetDT(year: 1980, hour: 3) | mkStringValue("03:10:09+10:00")
+        mkZonedDT(year: 1980, hour: 3)  | mkStringValue("03:10:09+10:00")
     }
 
     def "datetime serialisation bad inputs"() {

--- a/src/test/groovy/graphql/scalars/locale/LocaleScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/locale/LocaleScalarTest.groovy
@@ -20,10 +20,11 @@ class LocaleScalarTest extends Specification {
         then:
         result == expectedValue
         where:
-        input      | expectedValue
-        "en"       | mkLocale("en")
-        "ro-RO"    | mkLocale("ro-RO")
-        "zh-hakka" | mkLocale("zh-hakka")
+        input          | expectedValue
+        "en"           | mkLocale("en")
+        "ro-RO"        | mkLocale("ro-RO")
+        "zh-hakka"     | mkLocale("zh-hakka")
+        mkLocale("en") | mkLocale("en")
     }
 
     @Unroll

--- a/src/test/groovy/graphql/scalars/locale/LocaleScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/locale/LocaleScalarTest.groovy
@@ -1,19 +1,16 @@
 package graphql.scalars.locale
 
 import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import static graphql.scalars.util.TestKit.mkLocalDate
-import static graphql.scalars.util.TestKit.mkLocalDate
-import static graphql.scalars.util.TestKit.mkLocalDate
 import static graphql.scalars.util.TestKit.mkLocale
-import static graphql.scalars.util.TestKit.mkOffsetDT
-import static graphql.scalars.util.TestKit.mkZonedDT
+import static graphql.scalars.util.TestKit.mkStringValue
 
 class LocaleScalarTest extends Specification {
 
-    def coercing = new LocaleScalar().getCoercing()
+    def coercing = ExtendedScalars.Locale.getCoercing()
 
     @Unroll
     def "full locale parseValue"() {
@@ -23,10 +20,10 @@ class LocaleScalarTest extends Specification {
         then:
         result == expectedValue
         where:
-        input                           | expectedValue
-        "en"                            | mkLocale("en")
-        "ro-RO"                         | mkLocale("ro-RO")
-        "zh-hakka"                      | mkLocale("zh-hakka")
+        input      | expectedValue
+        "en"       | mkLocale("en")
+        "ro-RO"    | mkLocale("ro-RO")
+        "zh-hakka" | mkLocale("zh-hakka")
     }
 
     @Unroll
@@ -36,8 +33,8 @@ class LocaleScalarTest extends Specification {
         then:
         result == expectedValue
         where:
-        input                           | expectedValue
-        new StringValue("ro-RO")        | mkLocale("ro-RO")
+        input                    | expectedValue
+        new StringValue("ro-RO") | mkLocale("ro-RO")
     }
 
     @Unroll
@@ -47,10 +44,23 @@ class LocaleScalarTest extends Specification {
         then:
         result == expectedValue
         where:
-        input                           | expectedValue
-        "ro-RO"                         | "ro-RO"
-        mkLocale("ro-RO")               | "ro-RO"
-        mkLocale("en")                  | "en"
+        input             | expectedValue
+        "ro-RO"           | "ro-RO"
+        mkLocale("ro-RO") | "ro-RO"
+        mkLocale("en")    | "en"
+    }
+
+    @Unroll
+    def "full Locale valueToLiteral"() {
+        when:
+        def result = coercing.valueToLiteral(input)
+        then:
+        result.isEqualTo(expectedValue)
+        where:
+        input             | expectedValue
+        "ro-RO"           | mkStringValue("ro-RO")
+        mkLocale("ro-RO") | mkStringValue("ro-RO")
+        mkLocale("en")    | mkStringValue("en")
     }
 
 }

--- a/src/test/groovy/graphql/scalars/numeric/NegativeFloatScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/numeric/NegativeFloatScalarTest.groovy
@@ -1,6 +1,8 @@
 package graphql.scalars.numeric
 
+
 import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -12,7 +14,7 @@ import static graphql.scalars.util.TestKit.mkFloatValue
 import static graphql.scalars.util.TestKit.mkIntValue
 
 class NegativeFloatScalarTest extends Specification {
-    def coercing = new NegativeFloatScalar().getCoercing()
+    def coercing = ExtendedScalars.NegativeFloat.getCoercing()
 
     @Unroll
     def "serialize"() {

--- a/src/test/groovy/graphql/scalars/numeric/NegativeIntScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/numeric/NegativeIntScalarTest.groovy
@@ -1,6 +1,7 @@
 package graphql.scalars.numeric
 
 import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -11,7 +12,7 @@ import static graphql.scalars.util.TestKit.assertValueOrException
 import static graphql.scalars.util.TestKit.mkIntValue
 
 class NegativeIntScalarTest extends Specification {
-    def coercing = new NegativeIntScalar().getCoercing()
+    def coercing = ExtendedScalars.NegativeInt.getCoercing()
 
     @Unroll
     def "serialize"() {

--- a/src/test/groovy/graphql/scalars/numeric/NonNegativeFloatScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/numeric/NonNegativeFloatScalarTest.groovy
@@ -1,6 +1,7 @@
 package graphql.scalars.numeric
 
 import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -12,7 +13,7 @@ import static graphql.scalars.util.TestKit.mkFloatValue
 import static graphql.scalars.util.TestKit.mkIntValue
 
 class NonNegativeFloatScalarTest extends Specification {
-    def coercing = new NonNegativeFloatScalar().getCoercing()
+    def coercing = ExtendedScalars.NonNegativeFloat.getCoercing()
 
     @Unroll
     def "serialize"() {

--- a/src/test/groovy/graphql/scalars/numeric/NonNegativeIntScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/numeric/NonNegativeIntScalarTest.groovy
@@ -1,6 +1,7 @@
 package graphql.scalars.numeric
 
 import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -11,7 +12,7 @@ import static graphql.scalars.util.TestKit.assertValueOrException
 import static graphql.scalars.util.TestKit.mkIntValue
 
 class NonNegativeIntScalarTest extends Specification {
-    def coercing = new NonNegativeIntScalar().getCoercing()
+    def coercing = ExtendedScalars.NonNegativeInt.getCoercing()
 
     @Unroll
     def "serialize"() {

--- a/src/test/groovy/graphql/scalars/numeric/NonPositiveFloatScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/numeric/NonPositiveFloatScalarTest.groovy
@@ -1,6 +1,7 @@
 package graphql.scalars.numeric
 
 import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -12,7 +13,7 @@ import static graphql.scalars.util.TestKit.mkFloatValue
 import static graphql.scalars.util.TestKit.mkIntValue
 
 class NonPositiveFloatScalarTest extends Specification {
-    def coercing = new NonPositiveFloatScalar().getCoercing()
+    def coercing = ExtendedScalars.NonPositiveFloat.getCoercing()
 
     @Unroll
     def "serialize"() {

--- a/src/test/groovy/graphql/scalars/numeric/NonPositiveIntScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/numeric/NonPositiveIntScalarTest.groovy
@@ -1,6 +1,7 @@
 package graphql.scalars.numeric
 
 import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -11,7 +12,7 @@ import static graphql.scalars.util.TestKit.assertValueOrException
 import static graphql.scalars.util.TestKit.mkIntValue
 
 class NonPositiveIntScalarTest extends Specification {
-    def coercing = new NonPositiveIntScalar().getCoercing()
+    def coercing = ExtendedScalars.NonPositiveInt.getCoercing()
 
     @Unroll
     def "serialize"() {

--- a/src/test/groovy/graphql/scalars/numeric/PositiveFloatScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/numeric/PositiveFloatScalarTest.groovy
@@ -1,6 +1,7 @@
 package graphql.scalars.numeric
 
 import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -12,7 +13,7 @@ import static graphql.scalars.util.TestKit.mkFloatValue
 import static graphql.scalars.util.TestKit.mkIntValue
 
 class PositiveFloatScalarTest extends Specification {
-    def coercing = new PositiveFloatScalar().getCoercing()
+    def coercing = ExtendedScalars.PositiveFloat.getCoercing()
 
     @Unroll
     def "serialize"() {

--- a/src/test/groovy/graphql/scalars/numeric/PositiveIntScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/numeric/PositiveIntScalarTest.groovy
@@ -1,6 +1,7 @@
 package graphql.scalars.numeric
 
 import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -11,7 +12,7 @@ import static graphql.scalars.util.TestKit.assertValueOrException
 import static graphql.scalars.util.TestKit.mkIntValue
 
 class PositiveIntScalarTest extends Specification {
-    def coercing = new PositiveIntScalar().getCoercing()
+    def coercing = ExtendedScalars.PositiveInt.getCoercing()
 
     @Unroll
     def "serialize"() {

--- a/src/test/groovy/graphql/scalars/regex/RegexScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/regex/RegexScalarTest.groovy
@@ -5,14 +5,17 @@ import graphql.scalars.ExtendedScalars
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
+import graphql.schema.GraphQLScalarType
 import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.util.regex.Pattern
 
+import static graphql.scalars.util.TestKit.mkStringValue
+
 class RegexScalarTest extends Specification {
 
-    RegexScalar phoneNumberScalar = ExtendedScalars.newRegexScalar("phoneNumber")
+    GraphQLScalarType phoneNumberScalar = ExtendedScalars.newRegexScalar("phoneNumber")
             .addPattern(Pattern.compile("\\([0-9]*\\)[0-9]*"))
             .build()
 
@@ -72,6 +75,18 @@ class RegexScalarTest extends Specification {
         where:
         input        || expectedResult
         "(02)998768" || "(02)998768"
+    }
+
+    @Unroll
+    def "basic regex valueToLiteral"() {
+
+        when:
+        def result = phoneNumberScalar.getCoercing().valueToLiteral(input)
+        then:
+        result.isEqualTo(expectedResult)
+        where:
+        input        || expectedResult
+        "(02)998768" || mkStringValue("(02)998768")
     }
 
     @Unroll

--- a/src/test/groovy/graphql/scalars/url/UrlScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/url/UrlScalarTest.groovy
@@ -2,15 +2,18 @@ package graphql.scalars.url
 
 import graphql.language.BooleanValue
 import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import static graphql.scalars.util.TestKit.mkStringValue
+
 class UrlScalarTest extends Specification {
 
-    def coercing = new UrlScalar().getCoercing()
+    def coercing = ExtendedScalars.Url.getCoercing()
 
     @Unroll
     def "test serialize"() {
@@ -25,6 +28,21 @@ class UrlScalarTest extends Specification {
         new URI("http://www.graphql-java.com/") | new URL("http://www.graphql-java.com/")
         new File("/this/that")                  | new URL("file:/this/that")
         "http://www.graphql-java.com/"          | new URL("http://www.graphql-java.com/")
+    }
+
+    @Unroll
+    def "test valueToLiteral"() {
+
+        when:
+        def result = coercing.valueToLiteral(input)
+        then:
+        result.isEqualTo(expectedResult)
+        where:
+        input                                   | expectedResult
+        new URL("http://www.graphql-java.com/") | mkStringValue("http://www.graphql-java.com/")
+        new URI("http://www.graphql-java.com/") | mkStringValue("http://www.graphql-java.com/")
+        new File("/this/that")                  | mkStringValue("file:/this/that")
+        "http://www.graphql-java.com/"          | mkStringValue("http://www.graphql-java.com/")
     }
 
     @Unroll

--- a/src/test/groovy/graphql/scalars/util/TestKit.groovy
+++ b/src/test/groovy/graphql/scalars/util/TestKit.groovy
@@ -2,6 +2,7 @@ package graphql.scalars.util
 
 import graphql.language.FloatValue
 import graphql.language.IntValue
+import graphql.language.StringValue
 
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -69,6 +70,10 @@ class TestKit {
 
     static FloatValue mkFloatValue(String s) {
         return new FloatValue(new BigDecimal(String.valueOf(s)))
+    }
+
+    static StringValue mkStringValue(String s) {
+        return new StringValue(s)
     }
 
     static FloatValue mkFloatValue(double d) {


### PR DESCRIPTION
graphql-java 17 changed the constructors on scalars to encourage that fact that they MUST be singletons.

This updates the scalars here so that they can be used as such