### PR TITLE
Add support for Instant and Date in DateTime scalar

### DIFF
--- a/src/main/java/graphql/scalars/datetime/DateTimeScalar.java
+++ b/src/main/java/graphql/scalars/datetime/DateTimeScalar.java
@@ -16,6 +16,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Date;
 import java.util.function.Function;
 
 import static graphql.scalars.util.Kit.typeName;
@@ -39,6 +40,8 @@ public class DateTimeScalar {
                     offsetDateTime = ((ZonedDateTime) input).toOffsetDateTime();
                 } else if (input instanceof Instant) {
                     offsetDateTime = ((Instant) input).atOffset(ZoneOffset.UTC);
+                } else if (input instanceof Date) {
+                    offsetDateTime = ((Date) input).toInstant().atOffset(ZoneOffset.UTC);
                 } else if (input instanceof String) {
                     offsetDateTime = parseOffsetDateTime(input.toString(), CoercingSerializeException::new);
                 } else {
@@ -64,6 +67,8 @@ public class DateTimeScalar {
                     offsetDateTime = ((ZonedDateTime) input).toOffsetDateTime();
                 } else if (input instanceof Instant) {
                     offsetDateTime = ((Instant) input).atOffset(ZoneOffset.UTC);
+                } else if (input instanceof Date) {
+                    offsetDateTime = ((Date) input).toInstant().atOffset(ZoneOffset.UTC);
                 } else if (input instanceof String) {
                     offsetDateTime = parseOffsetDateTime(input.toString(), CoercingParseValueException::new);
                 } else {

--- a/src/main/java/graphql/scalars/datetime/DateTimeScalar.java
+++ b/src/main/java/graphql/scalars/datetime/DateTimeScalar.java
@@ -10,7 +10,9 @@ import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
 
 import java.time.DateTimeException;
+import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -35,6 +37,8 @@ public class DateTimeScalar {
                     offsetDateTime = (OffsetDateTime) input;
                 } else if (input instanceof ZonedDateTime) {
                     offsetDateTime = ((ZonedDateTime) input).toOffsetDateTime();
+                } else if (input instanceof Instant) {
+                    offsetDateTime = ((Instant) input).atOffset(ZoneOffset.UTC);
                 } else if (input instanceof String) {
                     offsetDateTime = parseOffsetDateTime(input.toString(), CoercingSerializeException::new);
                 } else {
@@ -58,6 +62,8 @@ public class DateTimeScalar {
                     offsetDateTime = (OffsetDateTime) input;
                 } else if (input instanceof ZonedDateTime) {
                     offsetDateTime = ((ZonedDateTime) input).toOffsetDateTime();
+                } else if (input instanceof Instant) {
+                    offsetDateTime = ((Instant) input).atOffset(ZoneOffset.UTC);
                 } else if (input instanceof String) {
                     offsetDateTime = parseOffsetDateTime(input.toString(), CoercingParseValueException::new);
                 } else {

--- a/src/test/groovy/graphql/scalars/datetime/DateTimeScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/DateTimeScalarTest.groovy
@@ -7,6 +7,7 @@ import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import static graphql.scalars.util.TestKit.mkInstant
 import static graphql.scalars.util.TestKit.mkLocalDT
 import static graphql.scalars.util.TestKit.mkOffsetDT
 import static graphql.scalars.util.TestKit.mkStringValue
@@ -30,6 +31,7 @@ class DateTimeScalarTest extends Specification {
         "1937-01-01T12:00:27.87+00:20"  | mkOffsetDT("1937-01-01T12:00:27.87+00:20")
         mkOffsetDT(year: 1980, hour: 3) | mkOffsetDT("1980-08-08T03:10:09+10:00")
         mkZonedDT(year: 1980, hour: 3)  | mkOffsetDT("1980-08-08T03:10:09+10:00")
+        mkInstant(year: 1980, hour: 3)  | mkOffsetDT("1980-08-08T03:10:09Z")
     }
 
     @Unroll
@@ -46,6 +48,7 @@ class DateTimeScalarTest extends Specification {
         "1937-01-01T12:00:27.87+00:20"  | mkStringValue("1937-01-01T12:00:27.87+00:20")
         mkOffsetDT(year: 1980, hour: 3) | mkStringValue("1980-08-08T03:10:09+10:00")
         mkZonedDT(year: 1980, hour: 3)  | mkStringValue("1980-08-08T03:10:09+10:00")
+        mkInstant(year: 1980, hour: 3)  | mkStringValue("1980-08-08T03:10:09Z")
     }
 
     @Unroll
@@ -86,6 +89,7 @@ class DateTimeScalarTest extends Specification {
         "1937-01-01T12:00:27.87+00:20"  | "1937-01-01T12:00:27.87+00:20"
         mkOffsetDT(year: 1980, hour: 3) | "1980-08-08T03:10:09+10:00"
         mkZonedDT(year: 1980, hour: 3)  | "1980-08-08T03:10:09+10:00"
+        mkInstant(year: 1980, hour: 3)  | "1980-08-08T03:10:09Z"
     }
 
     def "datetime serialisation bad inputs"() {

--- a/src/test/groovy/graphql/scalars/datetime/DateTimeScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/DateTimeScalarTest.groovy
@@ -7,6 +7,7 @@ import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import static graphql.scalars.util.TestKit.mkDate
 import static graphql.scalars.util.TestKit.mkInstant
 import static graphql.scalars.util.TestKit.mkLocalDT
 import static graphql.scalars.util.TestKit.mkOffsetDT
@@ -32,6 +33,7 @@ class DateTimeScalarTest extends Specification {
         mkOffsetDT(year: 1980, hour: 3) | mkOffsetDT("1980-08-08T03:10:09+10:00")
         mkZonedDT(year: 1980, hour: 3)  | mkOffsetDT("1980-08-08T03:10:09+10:00")
         mkInstant(year: 1980, hour: 3)  | mkOffsetDT("1980-08-08T03:10:09Z")
+        mkDate(year: 1980, hour: 3)     | mkOffsetDT("1980-08-08T03:10:09Z")
     }
 
     @Unroll
@@ -49,6 +51,7 @@ class DateTimeScalarTest extends Specification {
         mkOffsetDT(year: 1980, hour: 3) | mkStringValue("1980-08-08T03:10:09+10:00")
         mkZonedDT(year: 1980, hour: 3)  | mkStringValue("1980-08-08T03:10:09+10:00")
         mkInstant(year: 1980, hour: 3)  | mkStringValue("1980-08-08T03:10:09Z")
+        mkDate(year: 1980, hour: 3)     | mkStringValue("1980-08-08T03:10:09Z")
     }
 
     @Unroll
@@ -90,6 +93,7 @@ class DateTimeScalarTest extends Specification {
         mkOffsetDT(year: 1980, hour: 3) | "1980-08-08T03:10:09+10:00"
         mkZonedDT(year: 1980, hour: 3)  | "1980-08-08T03:10:09+10:00"
         mkInstant(year: 1980, hour: 3)  | "1980-08-08T03:10:09Z"
+        mkDate(year: 1980, hour: 3)     | "1980-08-08T03:10:09Z"
     }
 
     def "datetime serialisation bad inputs"() {

--- a/src/test/groovy/graphql/scalars/util/TestKit.groovy
+++ b/src/test/groovy/graphql/scalars/util/TestKit.groovy
@@ -4,6 +4,7 @@ import graphql.language.FloatValue
 import graphql.language.IntValue
 import graphql.language.StringValue
 
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
@@ -43,6 +44,11 @@ class TestKit {
     static ZonedDateTime mkZonedDT(args) {
         ZonedDateTime.of(args.year ?: 1969, args.month ?: 8, args.day ?: 8, args.hour ?: 11,
                 args.min ?: 10, args.secs ?: 9, args.nanos ?: 0, ZoneId.ofOffset("", ZoneOffset.ofHours(10)))
+    }
+
+    static Instant mkInstant(args) {
+        OffsetDateTime.of(args.year ?: 1969, args.month ?: 8, args.day ?: 8, args.hour ?: 11,
+                args.min ?: 10, args.secs ?: 9, args.nanos ?: 0, ZoneOffset.UTC).toInstant()
     }
 
 

--- a/src/test/groovy/graphql/scalars/util/TestKit.groovy
+++ b/src/test/groovy/graphql/scalars/util/TestKit.groovy
@@ -51,6 +51,10 @@ class TestKit {
                 args.min ?: 10, args.secs ?: 9, args.nanos ?: 0, ZoneOffset.UTC).toInstant()
     }
 
+    static Date mkDate(args) {
+        Date.from(mkInstant(args))
+    }
+
 
     static assertValueOrException(result, expectedResult) {
         if (result instanceof Exception) {


### PR DESCRIPTION
Add support for Instant and Date types in the DateTime scalar.

Similar to #26 but with the proposed fixes.