### PR TITLE
Configure Manifest task to create valid OSGi bundle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
+    id "biz.aQute.bnd.builder" version "6.2.0"
 }
 
 def getDevelopmentVersion() {
@@ -135,3 +136,10 @@ tasks.withType(PublishToMavenRepository) {
     dependsOn build
 }
 
+jar {
+    manifest {
+        attributes('Automatic-Module-Name': 'graphql-java-extended-scalars',
+                '-exportcontents': 'graphql.scalars.*',
+                '-removeheaders': 'Private-Package')
+    }
+}


### PR DESCRIPTION
Fixes same issue as in java-dataloader: https://github.com/graphql-java/java-dataloader/issues/106
Manifest misses export-package.

Manifest before:
```
Manifest-Version: 1.0
Bnd-LastModified: 1648362435798
Bundle-ManifestVersion: 2
Bundle-Name: graphql-java-extended-scalars
Bundle-SymbolicName: graphql-java-extended-scalars
Bundle-Version: 2022.0.0.03-27T08-27-15-8c3b172
Created-By: 1.8.0_121 (Oracle Corporation)
Import-Package: graphql;version="[17.0,18)",graphql.language;version="
 [17.0,18)",graphql.schema;version="[17.0,18)",graphql.util;version="[
 17.0,18)"
Private-Package: graphql.scalars,graphql.scalars.alias,graphql.scalars
 .datetime,graphql.scalars.id,graphql.scalars.java,graphql.scalars.loc
 ale,graphql.scalars.numeric,graphql.scalars.object,graphql.scalars.re
 gex,graphql.scalars.url,graphql.scalars.util
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
Tool: Bnd-6.2.0.202202251641
```

Manifest now:
```
Manifest-Version: 1.0
Automatic-Module-Name: com.graphql-java-extended-scalars
Bnd-LastModified: 1648362316389
Bundle-ManifestVersion: 2
Bundle-Name: graphql-java-extended-scalars
Bundle-SymbolicName: graphql-java-extended-scalars
Bundle-Version: 2022.0.0.03-27T08-25-16-8c3b172
Created-By: 1.8.0_121 (Oracle Corporation)
Export-Package: graphql.scalars;uses:="graphql,graphql.scalars.alias,g
 raphql.scalars.regex,graphql.schema";version="2022.0.0",graphql.scala
 rs.alias;uses:="graphql,graphql.schema";version="2022.0.0",graphql.sc
 alars.datetime;uses:="graphql,graphql.schema";version="2022.0.0",grap
 hql.scalars.id;uses:="graphql,graphql.schema";version="2022.0.0",grap
 hql.scalars.java;uses:="graphql,graphql.schema";version="2022.0.0",gr
 aphql.scalars.locale;uses:="graphql,graphql.schema";version="2022.0.0
 ",graphql.scalars.numeric;uses:="graphql,graphql.schema";version="202
 2.0.0",graphql.scalars.object;uses:="graphql,graphql.schema";version=
 "2022.0.0",graphql.scalars.regex;uses:="graphql,graphql.schema";versi
 on="2022.0.0",graphql.scalars.url;uses:="graphql,graphql.schema";vers
 ion="2022.0.0",graphql.scalars.util;version="2022.0.0"
Import-Package: graphql;version="[17.0,18)",graphql.language;version="
 [17.0,18)",graphql.scalars.alias,graphql.scalars.datetime,graphql.sca
 lars.id,graphql.scalars.java,graphql.scalars.locale,graphql.scalars.n
 umeric,graphql.scalars.object,graphql.scalars.regex,graphql.scalars.u
 rl,graphql.scalars.util,graphql.schema;version="[17.0,18)",graphql.ut
 il;version="[17.0,18)"
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
Tool: Bnd-6.2.0.202202251641
```


