### PR TITLE
chore(deps): Updating to use graphql-java 18.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
 
 
 dependencies {
-    compile "com.graphql-java:graphql-java:17.0"
+    compile "com.graphql-java:graphql-java:18.0"
 
     testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
     testImplementation('org.codehaus.groovy:groovy:2.5.13')


### PR DESCRIPTION
Bump dependency from `graphql-java:17.0` to `graphql-java:18.0`. 

Once merged, would be good to release a 18.x version of this library 🚀 