### PR TITLE
Fix invalid Automatic-Module-Name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ tasks.withType(PublishToMavenRepository) {
 
 jar {
     manifest {
-        attributes('Automatic-Module-Name': 'graphql-java-extended-scalars',
+        attributes('Automatic-Module-Name': 'graphql.java.extended.scalars',
                 '-exportcontents': 'graphql.scalars.*',
                 '-removeheaders': 'Private-Package')
     }


### PR DESCRIPTION
`-` is invalid in the `Automatic-Module-Name`

Related PRs: graphql-java/java-dataloader#104, graphql-java/graphql-java#2423

Fixes #60