### PR TITLE
Remove redundant NullValue case in ObjectScalar parseLiteral

### DIFF
--- a/src/main/java/graphql/scalars/object/ObjectScalar.java
+++ b/src/main/java/graphql/scalars/object/ObjectScalar.java
@@ -65,9 +65,6 @@ public final class ObjectScalar {
                         "Expected AST type 'Value' but was '" + typeName(input) + "'."
                 );
             }
-            if (input instanceof NullValue) {
-                return null;
-            }
             if (input instanceof FloatValue) {
                 return ((FloatValue) input).getValue();
             }

--- a/src/test/groovy/graphql/scalars/object/ObjectScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/object/ObjectScalarTest.groovy
@@ -37,7 +37,6 @@ class ObjectScalarTest extends Specification {
         mkIntValue(666)      | 666
         mkBooleanValue(true) | true
         mkEnumValue("enum")  | "enum"
-        mkNullValue()        | null
         mkVarRef("varRef1")  | "value1"
         mkArrayValue([
                 mkStringValue("s"), mkIntValue(666)


### PR DESCRIPTION
Inside `graphql-java`, a `NullValue` is always coerced into `null`, see `ValuesResolverConversion.literalToInternalValueImpl`. This happens before a scalar's `parseLiteral` method is called.

In other words, a scalar's `parseLiteral` method never needs to consider `NullValue`. This PR removes the redundant lines from `ObjectScalar`.

See further discussion: https://github.com/graphql-java/graphql-java/issues/2904