### PR TITLE
Add build workflow to release branches

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - master
+      - 19.x
+      - 18.x
+      - 17.x
 jobs:
   buildAndTest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is to prepare for a new v18 and v17 release, which will include the appropriate patched graphql-java version 

More info on the CVE: https://www.cve.org/CVERecord?id=CVE-2022-37734