### PR TITLE
v18 release: Update graphql-java version including patch for CVE-2022-37734

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ repositories {
 
 
 dependencies {
-    compile "com.graphql-java:graphql-java:18.1"
+    compile "com.graphql-java:graphql-java:18.3"
 
     testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
     testImplementation('org.codehaus.groovy:groovy:2.5.13')

--- a/readme.md
+++ b/readme.md
@@ -16,14 +16,14 @@ You would use custom scalars when you want to describe more meaningful behavior 
 
 To use this library put the following into your gradle config
 
-    compile 'com.graphql-java:graphql-java-extended-scalars:17.0'
+    compile 'com.graphql-java:graphql-java-extended-scalars:18.2
     
 or the following into your Maven config
 
     <dependency>
       <groupId>com.graphql-java</groupId>
       <artifactId>graphql-java-extended-scalars</artifactId>
-      <version>17.0</version>
+      <version>18.2</version>
     </dependency>
 
 > Note:
@@ -35,6 +35,8 @@ or the following into your Maven config
 > use 16.0.0 or above for graphql-java 16.x and above
 >
 > use 17.0 or above for graphql-java 17.x and above
+>
+> use 18.0 or above for graphql-java 18.x and above
 
 It's currently available from Maven Central.
 


### PR DESCRIPTION
This will be a special v18 release of the library, which includes v18.3 of graphql-java containing the patch for CVE-2022-37734

https://www.cve.org/CVERecord?id=CVE-2022-37734