### PR TITLE
Update graphql-java to v17.4 containing patch for CVE-2022-37734

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
 
 
 dependencies {
-    compile "com.graphql-java:graphql-java:17.0"
+    compile "com.graphql-java:graphql-java:17.4"
 
     testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
     testImplementation('org.codehaus.groovy:groovy:2.5.13')

--- a/readme.md
+++ b/readme.md
@@ -16,14 +16,14 @@ You would use custom scalars when you want to describe more meaningful behavior 
 
 To use this library put the following into your gradle config
 
-    compile 'com.graphql-java:graphql-java-extended-scalars:16.0.0'
+    compile 'com.graphql-java:graphql-java-extended-scalars:17.1'
     
 or the following into your Maven config
 
     <dependency>
       <groupId>com.graphql-java</groupId>
       <artifactId>graphql-java-extended-scalars</artifactId>
-      <version>16.0.0</version>
+      <version>17.1</version>
     </dependency>
 
 > Note:
@@ -33,6 +33,8 @@ or the following into your Maven config
 > use 15.0.0 or above for graphql-java 15.x and above
 >
 > use 16.0.0 or above for graphql-java 16.x and above
+>
+> use 17.0.0 or above for graphql-java 17.x and above
 
 Its currently available from JCenter repo and Maven central.
 


### PR DESCRIPTION
Preparing for a special bugfix release of v17 to include the corresponding patched version of graphql-java (v17.4)

https://www.cve.org/CVERecord?id=CVE-2022-37734