### PR TITLE
Remove dashes from Automatic-Module-Name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ tasks.withType(PublishToMavenRepository) {
 
 jar {
     manifest {
-        attributes('Automatic-Module-Name': 'graphql-java-extended-scalars',
+        attributes('Automatic-Module-Name': 'com.graphqljava.extendedscalars',
                 '-exportcontents': 'graphql.scalars.*',
                 '-removeheaders': 'Private-Package')
     }


### PR DESCRIPTION
Thanks to everyone who reported the issue. The invalid dashes in the `Automatic-Module-Name` was a problem.

This name aligns with the `Automatic-Module-Name` `com.graphqljava` for the GraphQL Java jar.

https://github.com/graphql-java/graphql-java-extended-scalars/issues/70
https://github.com/graphql-java/graphql-java-extended-scalars/issues/60
https://github.com/graphql-java/graphql-java-extended-scalars/pull/65