### PR TITLE
Backport the automatic module name fix to 18.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ tasks.withType(PublishToMavenRepository) {
 
 jar {
     manifest {
-        attributes('Automatic-Module-Name': 'graphql-java-extended-scalars',
+        attributes('Automatic-Module-Name': 'com.graphqljava.extendedscalars',
                 '-exportcontents': 'graphql.scalars.*',
                 '-removeheaders': 'Private-Package')
     }


### PR DESCRIPTION
Back port https://github.com/graphql-java/graphql-java-extended-scalars/pull/79 to 18.x.