### PR TITLE
Update DateTimeScalar with Custom Scalar specification, add new official specifiedByURL

### DIFF
--- a/src/test/groovy/graphql/scalars/datetime/DateTimeScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/DateTimeScalarTest.groovy
@@ -2,6 +2,7 @@ package graphql.scalars.datetime
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
 import spock.lang.Specification
@@ -28,6 +29,7 @@ class DateTimeScalarTest extends Specification {
         "1985-04-12T23:20:50.52Z"       | mkOffsetDT("1985-04-12T23:20:50.52Z")
         "1996-12-19T16:39:57-08:00"     | mkOffsetDT("1996-12-19T16:39:57-08:00")
         "1937-01-01T12:00:27.87+00:20"  | mkOffsetDT("1937-01-01T12:00:27.87+00:20")
+        "2022-11-24T01:00:01.02+00:00"  | mkOffsetDT("2022-11-24T01:00:01.02+00:00")
         mkOffsetDT(year: 1980, hour: 3) | mkOffsetDT("1980-08-08T03:10:09+10:00")
         mkZonedDT(year: 1980, hour: 3)  | mkOffsetDT("1980-08-08T03:10:09+10:00")
     }
@@ -45,6 +47,7 @@ class DateTimeScalarTest extends Specification {
         "1996-12-19T16:39:57-08:00"     | mkStringValue("1996-12-19T16:39:57.000-08:00")
         "1937-01-01T12:00:27.87+00:20"  | mkStringValue("1937-01-01T12:00:27.870+00:20")
         "1937-01-01T12:00+00:20"        | mkStringValue("1937-01-01T12:00:00.000+00:20")
+        "2022-11-24T01:00:01.02+00:00"  | mkStringValue("2022-11-24T01:00:01.020Z")
         mkOffsetDT(year: 1980, hour: 3) | mkStringValue("1980-08-08T03:10:09.000+10:00")
         mkZonedDT(year: 1980, hour: 3)  | mkStringValue("1980-08-08T03:10:09.000+10:00")
     }
@@ -59,6 +62,7 @@ class DateTimeScalarTest extends Specification {
         where:
         input                          | expectedValue
         "1985-04-12"                   | CoercingParseValueException
+        "2022-11-24T01:00:01.02-00:00" | CoercingParseValueException
         mkLocalDT(year: 1980, hour: 3) | CoercingParseValueException
         666                           || CoercingParseValueException
     }
@@ -85,6 +89,7 @@ class DateTimeScalarTest extends Specification {
         "1985-04-12T23:20:50.52Z"       | "1985-04-12T23:20:50.520Z"
         "1996-12-19T16:39:57-08:00"     | "1996-12-19T16:39:57.000-08:00"
         "1937-01-01T12:00:27.87+00:20"  | "1937-01-01T12:00:27.870+00:20"
+        "2022-11-24T01:00:01.02+00:00"  | "2022-11-24T01:00:01.020Z"
         mkOffsetDT(year: 1980, hour: 3) | "1980-08-08T03:10:09.000+10:00"
         mkZonedDT(year: 1980, hour: 3)  | "1980-08-08T03:10:09.000+10:00"
     }
@@ -98,8 +103,21 @@ class DateTimeScalarTest extends Specification {
         where:
         input                          | expectedValue
         "1985-04-12"                   | CoercingSerializeException
+        "2022-11-24T01:00:01.02-00:00" | CoercingSerializeException
         mkLocalDT(year: 1980, hour: 3) | CoercingSerializeException
         666                           || CoercingSerializeException
+    }
+
+    @Unroll
+    def "datetime parseLiteral bad inputs"() {
+
+        when:
+        coercing.parseLiteral(input)
+        then:
+        thrown(expectedValue)
+        where:
+        input                          | expectedValue
+        "2022-11-24T01:00:01.02-00:00" | CoercingParseLiteralException
     }
 
 }


### PR DESCRIPTION
Hot off the press, we have an official place for contributed Custom Scalar specifications! https://scalars.graphql.org/

And the very first specification is for DateTimeScalar https://scalars.graphql.org/andimarek/date-time

This PR:
* Updates the DateTimeScalar to conform with the specification, to not allow negative 0 offset for time zone
* Adds the link to the official custom scalar specification

Note that in the forthcoming `graphql-java` v20, the method to specify the URL will change to `specifiedByURL`.