### PR TITLE
Fix bug when NullValue is nested inside ObjectValue

### DIFF
--- a/src/main/java/graphql/scalars/object/ObjectScalar.java
+++ b/src/main/java/graphql/scalars/object/ObjectScalar.java
@@ -54,7 +54,6 @@ public final class ObjectScalar {
         @Override
         public Object parseLiteral(Object input) throws CoercingParseLiteralException {
             // on purpose - object scalars can be null
-            //noinspection ConstantConditions
             return parseLiteral(input, Collections.emptyMap());
         }
 
@@ -94,7 +93,12 @@ public final class ObjectScalar {
                 List<ObjectField> values = ((ObjectValue) input).getObjectFields();
                 Map<String, Object> parsedValues = new LinkedHashMap<>();
                 values.forEach(fld -> {
-                    Object parsedValue = parseLiteral(fld.getValue(), variables);
+                    Object parsedValue;
+                    if (fld.getValue() instanceof NullValue) { // Nested NullValue inside ObjectValue
+                        parsedValue = null;
+                    } else {
+                        parsedValue = parseLiteral(fld.getValue(), variables);
+                    }
                     parsedValues.put(fld.getName(), parsedValue);
                 });
                 return parsedValues;

--- a/src/test/groovy/graphql/scalars/object/ObjectScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/object/ObjectScalarTest.groovy
@@ -60,6 +60,10 @@ class ObjectScalarTest extends Specification {
                         childFl2 : mkVarRef("varRef1")
                 ] as Map<String, Value>)
         ] as Map<String, Value>) | [fld1: "s", fld2: 99, fld3: [childFld1: "child1", childFl2: "value1"]]
+
+        mkObjectValue([
+                field1: mkNullValue()
+        ] as Map<String, Value>) | [field1: null] // Nested NullValue inside ObjectValue
     }
 
     @Unroll


### PR DESCRIPTION
Fixes #90, thanks @Kingson-de for reporting!

Enables `NullValue` to be nested inside `ObjectValue`.