### PR TITLE
Prepend 0.0.0 to master build versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ def getDevelopmentVersion() {
         println "git hash is empty: error: ${error.toString()}"
         throw new IllegalStateException("git hash could not be determined")
     }
-    new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date()) + "-" + gitHash
+    "0.0.0-" + new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date()) + "-" + gitHash
 }
 
 


### PR DESCRIPTION
graphql-java master build versions start with `0.0.0` so they never appear as the "latest" version on Maven, when version numbers are sorted in descending order.

Adding the same to this repo. Thanks to @mattTea for reporting the issue https://github.com/graphql-java/graphql-java/discussions/3106