### PR TITLE
docs: readme makeover

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,10 +293,12 @@ query {
 <td>Description</td>
 </tr>
 <tr>
-<td> `Url` </td>
+<td><pre>Url</pre></td>
 <td><pre lang="graphql">
 scalar URL
-@specifiedBy(url: "https://www.w3.org/Addressing/URL/url-spec.txt")
+  @specifiedBy(url: 
+    "https://www.w3.org/Addressing/URL/url-spec.txt"
+  )
 </pre>
 </td>
 <td>An url scalar that accepts string values like `https://www.w3.org/Addressing/URL/url-spec.txt` and produces `java.net.URL` objects at runtime.</td>

--- a/README.md
+++ b/README.md
@@ -81,9 +81,20 @@ type Something {
 
 ## Alias Scalars
 
-| Scalar Name     | Scalar Specification                           | Description                                                                       |
-| --------------- | ---------------------------------------------- | --------------------------------------------------------------------------------- |
-| `AliasedScalar` | <pre lang="graphql">scalar AliasedScalar</pre> | You can create aliases for existing scalars to add more semantic meaning to them. |
+<table>
+<tr>
+<td>Scalar Name</td>
+<td>Scalar Specification</td>
+<td>Description</td>
+</tr>
+<tr>
+<td><code>AliasedScalar</code></td>
+<td><pre lang="graphql">
+scalar AliasedScalar
+</pre></td>
+<td>You can create aliases for existing scalars to add more semantic meaning to them.</td>
+</tr>
+</table>
 
 For example a link to a social media post could be representing by a `String` but the name `SocialMediaLink` is a
 more semantically meaningful name for that scalar type.
@@ -107,12 +118,49 @@ type Customer {
 
 ## Date & Time Scalars
 
-| Scalar Name | Scalar Definition                                                                                                   | Description                                                                                                                                                    |
-| ----------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DateTime`  | <pre lang="graphql">scalar DateTime @specifiedBy(url: "https://scalars.graphql.org/andimarek/date-time.html")</pre> | An RFC-3339 compliant date time scalar that accepts string values like `1996-12-19T16:39:57-08:00` and produces `java.time.OffsetDateTime` objects at runtime. |
-| `Time`      | <pre lang="graphql">scalar Time @specifiedBy(url: "https://tools.ietf.org/html/rfc3339")</pre>                      | An RFC-3339 compliant time scalar that accepts string values like `16:39:57-08:00` and produces `java.time.OffsetTime` objects at runtime                      |
-| `LocalTime` | <pre lang="graphql">scalar LocalTime</pre>                                                                          | 24-hour clock time string in the format `hh:mm:ss.sss` or `hh:mm:ss` if partial seconds is zero and produces `java.time.LocalTime` objects at runtime.         |
-| `Date`      | <pre lang="graphql">scalar Date @specifiedBy(url: "https://tools.ietf.org/html/rfc3339")</pre>                      | An RFC-3339 compliant date scalar that accepts string values like `1996-12-19` and produces `java.time.LocalDate` objects at runtime                           |
+<table>
+<tr>
+<td>Scalar Name</td>
+<td>Scalar Specification</td>
+<td>Description</td>
+</tr>
+<tr>
+<td><code>DateTime</code></td>
+<td><pre lang="graphql">
+scalar DateTime
+  @specifiedBy(url: 
+    "https://scalars.graphql.org/andimarek/date-time.html"
+  )
+</pre></td>
+<td>A RFC-3339 compliant date time scalar that accepts string values like <code>1996-12-19T16:39:57-08:00</code> and produces <code>java.time.OffsetDateTime</code> objects at runtime.</td>
+</tr>
+<tr>
+<td><code>Date</code></td>
+<td><pre lang="graphql">
+scalar Date
+  @specifiedBy(url: 
+    ["https://tools.ietf.org/html/rfc3339](https://tools.ietf.org/html/rfc3339)"
+  )</pre></td>
+<td>A RFC-3339 compliant date scalar that accepts string values like <code>1996-12-19</code> and produces <code>java.time.LocalDate</code> objects at runtime.</td>
+</tr>
+<tr>
+<td><code>Time</code></td>
+<td><pre lang="graphql">
+scalar Time
+  @specifiedBy(url: 
+    "https://tools.ietf.org/html/rfc3339"
+  )
+</pre></td>
+<td>A RFC-3339 compliant time scalar that accepts string values like <code>16:39:57-08:00</code> and produces <code>java.time.OffsetTime</code> objects at runtime.</td>
+</tr>
+<tr>
+<td><code>LocalTime</code></td>
+<td><pre lang="graphql">
+scalar LocalTime
+</pre></td>
+<td>24-hour clock time string in the format <code>hh:mm:ss.sss</code> or <code>hh:mm:ss</code> if partial seconds is zero and produces <code>java.time.LocalTime</code> objects at runtime.</td>
+</tr>
+</table>
 
 An example declaration in SDL might be:
 
@@ -141,22 +189,73 @@ query {
 
 ## ID Scalars
 
-| Scalar Name | Scalar Definition                                                                              | Description                                                                                                                                                     |
-| ----------- | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `UUID`      | <pre lang="graphql">scalar UUID @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")</pre> | A universally unique identifier scalar that accepts uuid values like `2423f0a0-3b81-4115-a189-18df8b35e8fc` and produces `java.util.UUID` instances at runtime. |
+<table>
+<tr>
+<td>Scalar Name</td>
+<td>Scalar Specification</td>
+<td>Description</td>
+</tr>
+<tr>
+<td><code>UUID</code></td>
+<td><pre lang="graphql">
+scalar UUID
+  @specifiedBy(url: 
+    "https://tools.ietf.org/html/rfc4122"
+  )
+</pre></td>
+<td>A universally unique identifier scalar that accepts uuid values like `2423f0a0-3b81-4115-a189-18df8b35e8fc` and produces `java.util.UUID` instances at runtime.</td>
+</tr>
+</table>
 
 ## Numeric Scalars
 
-| Scalar Name        | Scalar Definition                                 | Description                                                   |
-| ------------------ | ------------------------------------------------- | ------------------------------------------------------------- |
-| `PositiveInt`      | <pre lang="graphql">scalar PositiveInt</pre>      | An `Int` scalar that MUST be greater than zero.               |
-| `NegativeInt`      | <pre lang="graphql">scalar NegativeInt</pre>      | An `Int` scalar that MUST be less than zero.                  |
-| `NonPositiveInt`   | <pre lang="graphql">scalar NonPositiveInt</pre>   | An `Int` scalar that MUST be less than or equal to zero.      |
-| `NonNegativeInt`   | <pre lang="graphql">scalar NonNegativeInt</pre>   | An `Int` scalar that MUST be greater than or equal to zero.   |
-| `PositiveFloat`    | <pre lang="graphql">scalar PositiveFloat</pre>    | An `Float` scalar that MUST be greater than zero.             |
-| `NegativeFloat`    | <pre lang="graphql">scalar NegativeFloat</pre>    | An `Float` scalar that MUST be less than zero.                |
-| `NonPositiveFloat` | <pre lang="graphql">scalar NonPositiveFloat</pre> | An `Float` scalar that MUST be less than or equal to zero.    |
-| `NonNegativeFloat` | <pre lang="graphql">scalar NonNegativeFloat</pre> | An `Float` scalar that MUST be greater than or equal to zero. |
+<table>
+<tr>
+<td>Scalar Name</td>
+<td>Scalar Specification</td>
+<td>Description</td>
+</tr>
+<tr>
+<td><code>PositiveInt</code></td>
+<td><pre lang="graphql">scalar PositiveInt</pre></td>
+<td>An <code>Int</code> scalar that MUST be greater than zero.</td>
+</tr>
+<tr>
+<td><code>NegativeInt</code></td>
+<td><pre lang="graphql">scalar NegativeInt</pre></td>
+<td>An <code>Int</code> scalar that MUST be less than zero.</td>
+</tr>
+<tr>
+<td><code>NonPositiveInt</code></td>
+<td><pre lang="graphql">scalar NonPositiveInt</pre></td>
+<td>An <code>Int</code> scalar that MUST be less than or equal to zero.</td>
+</tr>
+<tr>
+<td><code>NonNegativeInt</code></td>
+<td><pre lang="graphql">scalar NonNegativeInt</pre></td>
+<td>An <code>Int</code> scalar that MUST be greater than or equal to zero.</td>
+</tr>
+<tr>
+<td><code>PositiveFloat</code></td>
+<td><pre lang="graphql">scalar PositiveFloat</pre></td>
+<td>An <code>Float</code> scalar that MUST be greater than zero.</td>
+</tr>
+<tr>
+<td><code>NegativeFloat</code></td>
+<td><pre lang="graphql">scalar NegativeFloat</pre></td>
+<td>An <code>Float</code> scalar that MUST be less than zero.</td>
+</tr>
+<tr>
+<td><code>NonPositiveFloat</code></td>
+<td><pre lang="graphql">scalar NonPositiveFloat</pre></td>
+<td>An <code>Float</code> scalar that MUST be less than or equal to zero.</td>
+</tr>
+<tr>
+<td><code>NonNegativeFloat</code></td>
+<td><pre lang="graphql">scalar NonNegativeFloat</pre></td>
+<td>An <code>Float</code> scalar that MUST be greater than or equal to zero.</td>
+</tr>
+</table>
 
 The numeric scalars are derivations of the standard GraphQL `Int` and `Float` scalars that enforce range limits.
 
@@ -189,20 +288,63 @@ query {
 
 ## Java Primitives
 
-| Scalar Name         | Scalar Specification                               | Description                                      |
-| ------------------- | -------------------------------------------------- | ------------------------------------------------ |
-| `GraphQLLong`       | <pre lang="graphql">scalar GraphQLLong</pre>       | A scalar which represents `java.lang.Long`       |
-| `GraphQLShort`      | <pre lang="graphql">scalar GraphQLShort</pre>      | A scalar which represents `java.lang.Short`      |
-| `GraphQLByte`       | <pre lang="graphql">scalar GraphQLByte</pre>       | A scalar which represents `java.lang.Byte`       |
-| `GraphQLBigDecimal` | <pre lang="graphql">scalar GraphQLBigDecimal</pre> | A scalar which represents `java.math.BigDecimal` |
-| `GraphQLBigInteger` | <pre lang="graphql">scalar GraphQLBigInteger</pre> | A scalar which represents `java.math.BigInteger` |
-| `GraphQLChar`       | <pre lang="graphql">scalar GraphQLChar</pre>       | A scalar which represents `java.lang.Character`  |
+<table>
+<tr>
+<td>Scalar Name</td>
+<td>Scalar Specification</td>
+<td>Description</td>
+</tr>
+<tr>
+<td><code>GraphQLLong</code></td>
+<td><pre lang="graphql">scalar GraphQLLong</pre></td>
+<td>A scalar which represents <code>java.lang.Long<code></td>
+</tr>
+<tr>
+<td><code>GraphQLShort</code></td>
+<td><pre lang="graphql">scalar GraphQLShort</pre></td>
+<td>A scalar which represents <code>java.lang.Short<code></td>
+</tr>
+<tr>
+<td><code>GraphQLByte</code></td>
+<td><pre lang="graphql">scalar GraphQLByte</pre></td>
+<td>A scalar which represents <code>java.lang.Byte<code></td>
+</tr>
+<tr>
+<td><code>GraphQLBigDecimal</code></td>
+<td><pre lang="graphql">scalar GraphQLBigDecimal</pre></td>
+<td>A scalar which represents <code>java.lang.BigDecimal<code></td>
+</tr>
+<tr>
+<td><code>GraphQLBigInteger</code></td>
+<td><pre lang="graphql">scalar GraphQLBigInteger</pre></td>
+<td>A scalar which represents <code>java.lang.BigInteger<code></td>
+</tr>
+<tr>
+<td><code>GraphQLChar</code></td>
+<td><pre lang="graphql">scalar GraphQLChar</pre></td>
+<td>A scalar which represents <code>java.lang.Character<code></td>
+</tr>
+</table>
 
 ## Locale Scalar
 
-| Scalar Name | Scalar Specification                                                                           | Description                                                                                                                                                                                                                             |
-| ----------- | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Locale`    | <pre lang="graphql">scalar Locale @specifiedBy(url: "https://tools.ietf.org/html/bcp47")</pre> | The Locale scalar handles [IETF BCP 47](https://tools.ietf.org/html/bcp47) language tags via the JDK method [Locale.forLanguageTag](<https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html#forLanguageTag(java.lang.String)>) |
+<table>
+<tr>
+<td>Scalar Name</td>
+<td>Scalar Specification</td>
+<td>Description</td>
+</tr>
+<tr>
+<td><code>Locale</code></td>
+<td><pre lang="graphql">
+scalar Locale
+  @specifiedBy(url: 
+    "https://tools.ietf.org/html/bcp47"
+  )
+</pre></td>
+<td>The Locale scalar handles <a href="https://tools.ietf.org/html/bcp47">IETF BCP 47</a> language tags via the JDK method <a href="https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html#forLanguageTag(java.lang.String)">Locale.forLanguageTag</a>.</td>
+</tr>
+</table>
 
 ```graphql
 type Customer {
@@ -228,9 +370,23 @@ query {
 
 ## Country Code Scalar
 
-| Scalar Name   | Scalar Specification                         | Description                                                                                                       |
-| ------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `CountryCode` | <pre lang="graphql">scalar CountryCode</pre> | The CountryCode scalar type as defined by [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). |
+<table>
+<tr>
+<td>Scalar Name</td>
+<td>Scalar Specification</td>
+<td>Description</td>
+</tr>
+<tr>
+<td><code>CountryCode</code></td>
+<td><pre lang="graphql">
+scalar CountryCode 
+  @specifiedBy(url: 
+    "https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2"
+  )
+</pre></td>
+<td>The CountryCode scalar type as defined by <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a>.</td>
+</tr>
+</table>
 
 An example declaration in SDL might be:
 
@@ -256,9 +412,23 @@ query {
 
 ## Currency Scalar
 
-| Scalar Name | Scalar Specification                      | Description                                                                            |
-| ----------- | ----------------------------------------- | -------------------------------------------------------------------------------------- |
-| `Currency`  | <pre lang="graphql">scalar Currency</pre> | A field whose value is an [ISO-4217](https://en.wikipedia.org/wiki/ISO_4217) currency. |
+<table>
+<tr>
+<td>Scalar Name</td>
+<td>Scalar Specification</td>
+<td>Description</td>
+</tr>
+<tr>
+<td><code>Currency</code></td>
+<td><pre lang="graphql">
+scalar Currency
+  @specifiedBy(url: 
+    "https://en.wikipedia.org/wiki/ISO_4217"
+  )
+</pre></td>
+<td>A field whose value is an <a href="https://en.wikipedia.org/wiki/ISO_4217">ISO-4217</a> currency.</td>
+</tr>
+</table>
 
 An example declaration in SDL might be:
 
@@ -293,28 +463,36 @@ query {
 <td>Description</td>
 </tr>
 <tr>
-<td><pre>Url</pre></td>
+<td><code>Url</code></td>
 <td><pre lang="graphql">
 scalar URL
   @specifiedBy(url: 
     "https://www.w3.org/Addressing/URL/url-spec.txt"
   )
-</pre>
-</td>
+</pre></td>
 <td>An url scalar that accepts string values like `https://www.w3.org/Addressing/URL/url-spec.txt` and produces `java.net.URL` objects at runtime.</td>
 </tr>
 </table>
 
-| Scalar Name | Scalar Specification                                                                                     | Description                                                                                                                                    |
-| ----------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Url`       | <pre lang="graphql">scalar URL @specifiedBy(url: "https://www.w3.org/Addressing/URL/url-spec.txt")</pre> | An url scalar that accepts string values like `https://www.w3.org/Addressing/URL/url-spec.txt` and produces `java.net.URL` objects at runtime. |
-
 ## Object / JSON Scalars
 
-| Scalar Name | Scalar Specification                    | Description                                                                     |
-| ----------- | --------------------------------------- | ------------------------------------------------------------------------------- |
-| `Object`    | <pre lang="graphql">scalar Object</pre> | An object scalar that accepts any object as a scalar value.                     |
-| `JSON`      | <pre lang="graphql">scalar JSON</pre>   | A synonym for the `Object` scalar, it will accept any object as a scalar value. |
+<table>
+<tr>
+<td>Scalar Name</td>
+<td>Scalar Specification</td>
+<td>Description</td>
+</tr>
+<tr>
+<td><code>Object</code></td>
+<td><pre lang="graphql">scalar Object</pre></td>
+<td>An object scalar that accepts any object as a scalar value.</td>
+</tr>
+<tr>
+<td><code>JSON</code></td>
+<td><pre lang="graphql">scalar JSON</pre></td>
+<td>A synonym for the `Object` scalar, it will accept any object as a scalar value.</td>
+</tr>
+</table>
 
 One of the design goals of GraphQL, is that the type system describes the shape of the data returned.
 
@@ -360,9 +538,18 @@ adds more semantic readers to your schema consumers.
 
 ## Regex Scalars
 
-| Scalar Name   | Scalar Specification | Description                                                                      |
-| ------------- | -------------------- | -------------------------------------------------------------------------------- |
-| `RegexScalar` | -                    | Allows you to build a new scalar via a builder pattern using regular expressions |
+<table>
+<tr>
+<td>Scalar Name</td>
+<td>Scalar Specification</td>
+<td>Description</td>
+</tr>
+<tr>
+<td><code>RegexScalar</code></td>
+<td><pre lang="graphql">-</pre></td>
+<td>Allows you to build a new scalar via a builder pattern using regular expressions.</td>
+</tr>
+</table>
 
 The RegexScalar has a builder where you provide one or more regex patterns that control the acceptable values
 for a new scalar.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ This library provides extended scalars for [graphql-java](https://github.com/gra
 The GraphQL Specification defines `String`, `Int`, `Float`, `Boolean` and `ID` as well-defined [built-in scalars](https://spec.graphql.org/October2021/#sec-Scalars.Built-in-Scalars) that must be present in a graphql type
 system. Beyond these, it is up to an implementation about what [custom scalars](https://spec.graphql.org/October2021/#sec-Scalars.Custom-Scalars) are present.
 
-The GraphQL Specification recommends the use of the [@specifiedBy](https://spec.graphql.org/October2021/#sec--specifiedBy) built-in schema directive to provide a scalar specification URL for specifying the behavior of custom scalar types.
-
 You would use custom scalars when you want to describe more meaningful behavior or ranges of values.
 
 # Getting started
@@ -75,6 +73,12 @@ public class GraphQlConfig {
 If you are using [Netflix DGS](https://netflix.github.io/dgs), please see their [configuration documentation](https://netflix.github.io/dgs/configuration/#dgs-extended-scalars-graphql-dgs-extended-scalars)
 
 ## How to add extended scalars to your schema
+
+The GraphQL Specification recommends the use of the [@specifiedBy](https://spec.graphql.org/October2021/#sec--specifiedBy) built-in schema directive to provide a scalar specification URL for specifying the behavior of custom scalar types.
+
+```graphql
+directive @specifiedBy(url: String!) on SCALAR
+```
 
 To use a extended scalar in your schema, define the scalar like shown below for `DateTime`
 

--- a/README.md
+++ b/README.md
@@ -287,22 +287,23 @@ query {
 ## URL Scalars
 
 <table>
-<tr>
-<td>Scalar Name</td>
-<td>Scalar Specification</td>
-<td>Description</td>
-</tr>
-<tr>
-<td> `Url` </td>
-<td><pre lang="graphql">
-scalar URL
-  @specifiedBy(url: 
-    "https://www.w3.org/Addressing/URL/url-spec.txt"
-  )
-</ore>
-</td>
-<td>An url scalar that accepts string values like `https://www.w3.org/Addressing/URL/url-spec.txt` and produces `java.net.URL` objects at runtime.</td>
-</tr>
+  <tr>
+    <td>Scalar Name</td>
+    <td>Scalar Specification</td>
+    <td>Description</td>
+  </tr>
+  <tr>
+    <td> `Url` </td>
+    <td>
+      <pre lang="graphql">
+      scalar URL
+        @specifiedBy(url: 
+          "https://www.w3.org/Addressing/URL/url-spec.txt"
+        )
+      </ore>
+    </td>
+    <td>An url scalar that accepts string values like `https://www.w3.org/Addressing/URL/url-spec.txt` and produces `java.net.URL` objects at runtime.</td>
+  </tr>
 </table>
 
 | Scalar Name | Scalar Specification                                                                                     | Description                                                                                                                                    |

--- a/README.md
+++ b/README.md
@@ -286,6 +286,26 @@ query {
 
 ## URL Scalars
 
+<table>
+<tr>
+<td>Scalar Name</td>
+<td>Scalar Specification</td>
+<td>Description</td>
+</tr>
+<tr>
+<td> `Url` </td>
+<td>
+
+````graphql
+scalar URL
+@specifiedBy(url: "https://www.w3.org/Addressing/URL/url-spec.txt")
+```
+
+</td>
+<td>An url scalar that accepts string values like `https://www.w3.org/Addressing/URL/url-spec.txt` and produces `java.net.URL` objects at runtime.</td>
+</tr>
+</table>
+
 | Scalar Name | Scalar Specification                                                                                     | Description                                                                                                                                    |
 | ----------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Url`       | <pre lang="graphql">scalar URL @specifiedBy(url: "https://www.w3.org/Addressing/URL/url-spec.txt")</pre> | An url scalar that accepts string values like `https://www.w3.org/Addressing/URL/url-spec.txt` and produces `java.net.URL` objects at runtime. |
@@ -317,7 +337,7 @@ type Customer {
 type Query {
   customers(filterSyntax: JSON): [Customers]
 }
-```
+````
 
 And example query might look like:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This library provides extended scalars for [graphql-java](https://github.com/graphql-java/graphql-java)
 
-[GraphQL Scalars](https://spec.graphql.org/October2021/#sec-Scalars) are the leaf values in the GraphQL type system and can't be queried further via sub-field selections.
+[GraphQL Scalars](https://spec.graphql.org/draft/#sec-Scalars) are the primitive leaf values in the GraphQL type system and can't be queried further via sub-field selections.
 
 The GraphQL Specification defines `String`, `Int`, `Float`, `Boolean` and `ID` as well-defined [built-in scalars](https://spec.graphql.org/October2021/#sec-Scalars.Built-in-Scalars) that must be present in a graphql type
 system. Beyond these, it is up to an implementation about what [custom scalars](https://spec.graphql.org/October2021/#sec-Scalars.Custom-Scalars) are present.

--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ You would use custom scalars when you want to describe more meaningful behavior 
 To use this library put the following into your gradle config
 
 ```java
-    implementation 'com.graphql-java:graphql-java-extended-scalars:20.0'
+implementation 'com.graphql-java:graphql-java-extended-scalars:20.0'
 ```
 
 or the following into your Maven config
 
 ```xml
-    <dependency>
-      <groupId>com.graphql-java</groupId>
-      <artifactId>graphql-java-extended-scalars</artifactId>
-      <version>20.0</version>
-    </dependency>
+<dependency>
+  <groupId>com.graphql-java</groupId>
+  <artifactId>graphql-java-extended-scalars</artifactId>
+  <version>20.0</version>
+</dependency>
 ```
 
 > Note:
@@ -51,19 +51,19 @@ It's currently available from Maven Central.
 Register the scalar with `graphql-java`
 
 ```java
-    RuntimeWiring.newRuntimeWiring().scalar(ExtendedScalars.DateTime)
+RuntimeWiring.newRuntimeWiring().scalar(ExtendedScalars.DateTime)
 ```
 
 Or if using [Spring for GraphQL](https://docs.spring.io/spring-graphql/docs/current/reference/html/), register the scalar with `RuntimeWiringConfigurer`
 
 ```java
-    @Configuration
-    public class GraphQlConfig {
-        @Bean
-        public RuntimeWiringConfigurer runtimeWiringConfigurer() {
-            return wiringBuilder -> wiringBuilder.scalar(ExtendedScalars.DateTime);
-        }
+@Configuration
+public class GraphQlConfig {
+    @Bean
+    public RuntimeWiringConfigurer runtimeWiringConfigurer() {
+        return wiringBuilder -> wiringBuilder.scalar(ExtendedScalars.DateTime);
     }
+}
 ```
 
 And use the scalar in your schema
@@ -91,11 +91,9 @@ more semantically meaningful name for that scalar type.
 For example, you would build it like this:
 
 ```java
-
-    AliasedScalar socialMediaLink = ExtendedScalars.newAliasedScalar("SocialMediaLink")
-            .aliasedScalar(Scalars.GraphQLString)
-            .build()
-
+AliasedScalar socialMediaLink = ExtendedScalars.newAliasedScalar("SocialMediaLink")
+        .aliasedScalar(Scalars.GraphQLString)
+        .build()
 ```
 
 And use it in a SDL schema like this :
@@ -109,12 +107,12 @@ type Customer {
 
 ## Date & Time Scalars
 
-| Scalar Name | Scalar Definition                                                                                                                  | Description                                                                                                                                                    |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DateTime`  | <pre lang="graphql">scalar DateTime @specifiedBy(url: "https://scalars.graphql.org/andimarek/date-time.html")</pre lang="graphql"> | An RFC-3339 compliant date time scalar that accepts string values like `1996-12-19T16:39:57-08:00` and produces `java.time.OffsetDateTime` objects at runtime. |
-| `Time`      | <pre lang="graphql">scalar Time @specifiedBy(url: "https://tools.ietf.org/html/rfc3339")</pre>                                     | An RFC-3339 compliant time scalar that accepts string values like `16:39:57-08:00` and produces `java.time.OffsetTime` objects at runtime                      |
-| `LocalTime` | <pre lang="graphql">scalar LocalTime</pre>                                                                                         | 24-hour clock time string in the format `hh:mm:ss.sss` or `hh:mm:ss` if partial seconds is zero and produces `java.time.LocalTime` objects at runtime.         |
-| `Date`      | <pre lang="graphql">scalar Date @specifiedBy(url: "https://tools.ietf.org/html/rfc3339")</pre>                                     | An RFC-3339 compliant date scalar that accepts string values like `1996-12-19` and produces `java.time.LocalDate` objects at runtime                           |
+| Scalar Name | Scalar Definition                                                                                                   | Description                                                                                                                                                    |
+| ----------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DateTime`  | <pre lang="graphql">scalar DateTime @specifiedBy(url: "https://scalars.graphql.org/andimarek/date-time.html")</pre> | An RFC-3339 compliant date time scalar that accepts string values like `1996-12-19T16:39:57-08:00` and produces `java.time.OffsetDateTime` objects at runtime. |
+| `Time`      | <pre lang="graphql">scalar Time @specifiedBy(url: "https://tools.ietf.org/html/rfc3339")</pre>                      | An RFC-3339 compliant time scalar that accepts string values like `16:39:57-08:00` and produces `java.time.OffsetTime` objects at runtime                      |
+| `LocalTime` | <pre lang="graphql">scalar LocalTime</pre>                                                                          | 24-hour clock time string in the format `hh:mm:ss.sss` or `hh:mm:ss` if partial seconds is zero and produces `java.time.LocalTime` objects at runtime.         |
+| `Date`      | <pre lang="graphql">scalar Date @specifiedBy(url: "https://tools.ietf.org/html/rfc3339")</pre>                      | An RFC-3339 compliant date scalar that accepts string values like `1996-12-19` and produces `java.time.LocalDate` objects at runtime                           |
 
 An example declaration in SDL might be:
 

--- a/README.md
+++ b/README.md
@@ -48,13 +48,17 @@ It's currently available from Maven Central.
 
 ## How to use extended scalars
 
+### Direct use
+
 Register the scalar with `graphql-java`
 
 ```java
 RuntimeWiring.newRuntimeWiring().scalar(ExtendedScalars.DateTime)
 ```
 
-Or if using [Spring for GraphQL](https://docs.spring.io/spring-graphql/docs/current/reference/html/), register the scalar with `RuntimeWiringConfigurer`
+### Spring for GraphQL
+
+If you are using [Spring for GraphQL](https://docs.spring.io/spring-graphql/docs/current/reference/html/), register the scalar with `RuntimeWiringConfigurer`
 
 ```java
 @Configuration
@@ -66,7 +70,13 @@ public class GraphQlConfig {
 }
 ```
 
-And use the scalar in your schema
+### Netflix DGS
+
+If you are using [Netflix DGS](https://netflix.github.io/dgs) see their [configuration documentation](https://netflix.github.io/dgs/configuration/#dgs-extended-scalars-graphql-dgs-extended-scalars)
+
+## How to add extended scalars to your schema
+
+To use a extended scalar in your schema, define the scalar like shown below for `DateTime`
 
 ```graphql
 scalar DateTime

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ scalar Locale
     "https://tools.ietf.org/html/bcp47"
   )
 </pre></td>
-<td>The Locale scalar handles <a href="https://tools.ietf.org/html/bcp47">IETF BCP 47</a> language tags via the JDK method <a href="https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html#forLanguageTag(java.lang.String)">Locale.forLanguageTag</a>.</td>
+<td>The Locale scalar handles <a target="_blank" href="https://tools.ietf.org/html/bcp47">IETF BCP 47</a> language tags via the JDK method <a target="_blank" href="https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html#forLanguageTag(java.lang.String)">Locale.forLanguageTag</a>.</td>
 </tr>
 </table>
 
@@ -369,7 +369,7 @@ scalar CountryCode
     "https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2"
   )
 </pre></td>
-<td>The CountryCode scalar type as defined by <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a>.</td>
+<td>The CountryCode scalar type as defined by <a target="_blank" href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a>.</td>
 </tr>
 </table>
 
@@ -409,7 +409,7 @@ scalar Currency
     "https://en.wikipedia.org/wiki/ISO_4217"
   )
 </pre></td>
-<td>A field whose value is an <a href="https://en.wikipedia.org/wiki/ISO_4217">ISO-4217</a> currency.</td>
+<td>A field whose value is an <a target="_blank" href="https://en.wikipedia.org/wiki/ISO_4217">ISO-4217</a> currency.</td>
 </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ public class GraphQlConfig {
 
 ### Netflix DGS
 
-If you are using [Netflix DGS](https://netflix.github.io/dgs) see their [configuration documentation](https://netflix.github.io/dgs/configuration/#dgs-extended-scalars-graphql-dgs-extended-scalars)
+If you are using [Netflix DGS](https://netflix.github.io/dgs), please see their [configuration documentation](https://netflix.github.io/dgs/configuration/#dgs-extended-scalars-graphql-dgs-extended-scalars)
 
 ## How to add extended scalars to your schema
 

--- a/README.md
+++ b/README.md
@@ -5,21 +5,27 @@
 [![Latest Snapshot](https://img.shields.io/maven-central/v/com.graphql-java/graphql-java-extended-scalars?label=maven-central%20snapshot)](https://maven-badges.herokuapp.com/maven-central/com.graphql-java/graphql-java-extended-scalars/)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-green)](https://github.com/graphql-java/graphql-java-extended-scalars/blob/master/LICENSE.md)
 
+## Overview
 
 This library provides extended scalars for [graphql-java](https://github.com/graphql-java/graphql-java)
 
-Scalars in graphql are the leaf nodes of a query, the non-compound values that can't be queried further via sub-field selections.
+[GraphQL Scalars](https://spec.graphql.org/October2021/#sec-Scalars) are the leaf values in the GraphQL type system and can't be queried further via sub-field selections.
 
-The graphql standard specifies that the `String`, `Int`, `Float`, `Boolean` and `ID` scalars must be present in a graphql type 
-system but after that it is up to an implementation about what custom scalars are present.
+The GraphQL Specification defines `String`, `Int`, `Float`, `Boolean` and `ID` as well-defined [built-in scalars](https://spec.graphql.org/October2021/#sec-Scalars.Built-in-Scalars) that must be present in a graphql type
+system. Beyond these, it is up to an implementation about what [custom scalars](https://spec.graphql.org/October2021/#sec-Scalars.Custom-Scalars) are present.
+
+The GraphQL Specification recommends the use of the [@specifiedBy](https://spec.graphql.org/October2021/#sec--specifiedBy) built-in schema directive to provide a scalar specification URL for specifying the behavior of custom scalar types.
 
 You would use custom scalars when you want to describe more meaningful behavior or ranges of values.
 
+# Getting started
+
 ## How to install
+
 To use this library put the following into your gradle config
 
     implementation 'com.graphql-java:graphql-java-extended-scalars:20.0'
-    
+
 or the following into your Maven config
 
     <dependency>
@@ -31,19 +37,22 @@ or the following into your Maven config
 > Note:
 >
 > use 19.0 or above for graphql-java 19.x and above
-> 
+>
 > use 20.0 or above for graphql-java 20.x and above
-
 
 It's currently available from Maven Central.
 
 ## How to use extended scalars
-Register the scalar with graphql-java
 
+Register the scalar with `graphql-java`
+
+```java
     RuntimeWiring.newRuntimeWiring().scalar(ExtendedScalars.DateTime)
-    
+```
+
 Or if using [Spring for GraphQL](https://docs.spring.io/spring-graphql/docs/current/reference/html/), register the scalar with `RuntimeWiringConfigurer`
 
+```java
     @Configuration
     public class GraphQlConfig {
         @Bean
@@ -51,277 +60,27 @@ Or if using [Spring for GraphQL](https://docs.spring.io/spring-graphql/docs/curr
             return wiringBuilder -> wiringBuilder.scalar(ExtendedScalars.DateTime);
         }
     }
-
-And use the scalar in your schema
-    
-    scalar DateTime
-    type Something {
-        someDateTime: DateTime
-    }
-
-## DateTime Scalars
-
-* `DateTime`
-  * An RFC-3339 compliant date time scalar that accepts string values like `1996-12-19T16:39:57-08:00` and produces 
-  `java.time.OffsetDateTime` objects at runtime  
-* `Time`
-  * An RFC-3339 compliant time scalar that accepts string values like `16:39:57-08:00` and produces 
-  `java.time.OffsetTime` objects at runtime
-* `LocalTime`
-  * 24-hour clock time string in the format `hh:mm:ss.sss` or `hh:mm:ss` if partial seconds is zero and 
-  produces `java.time.LocalTime` objects at runtime.
-* `Date`
-  * An RFC-3339 compliant date scalar that accepts string values like `1996-12-19` and produces 
-  `java.time.LocalDate` objects at runtime  
-
-See [the rfc3339 spec](https://www.ietf.org/rfc/rfc3339.txt) for more details on the format.
-
-An example declaration in SDL might be:
-
-```graphql
-
-    type Customer {
-        birthDay : Date
-        workStartTime : Time
-        bornAt : DateTime
-    }
-    
-    type Query {
-        customers(bornAfter : DateTime) : [Customers]
-    }
-    
-``` 
-
-And example query might look like:
-```graphql
-    
-    query {
-        customers(bornAfter : "1996-12-19T16:39:57-08:00") {
-            birthDay
-            bornAt
-        }
-    }
-    
-``` 
-## ID Scalars
-
-* `UUID`
-    * A universally unique identifier scalar that accepts uuid values like `2423f0a0-3b81-4115-a189-18df8b35e8fc` and produces
-    `java.util.UUID` instances at runtime.
-
-## Object / JSON Scalars
-
-* `Object`
-  * An object scalar that accepts any object as a scalar value
-
-* `JSON`
-  * A synonym for the `Object` scalar, it will accept any object as a scalar value
-  
-One of the design goals of graphql, is that the type system describes the shape of the data returned.
-
-The `Object` / `JSON` scalars work against this some what because they can return compound values outside the type system.  As such 
-they should be used sparingly.  In general your should aim to describe the data via the graphql type system where you can and only
-resort to the `Object` / `JSON` scalars in very rare circumstances. 
-
-An example might be an extensible graphql system where systems can input custom metadata objects that cant be known at 
-schema type design time.
-
-An example declaration in SDL might be:
-
-```graphql
-
-    type Customer {
-        name : String
-        associatedMetaData : JSON
-    }
-    
-    type Query {
-        customers(filterSyntax : JSON) : [Customers]
-    }
-    
-``` 
-
-And example query might look like:
-
-```graphql
-    
-    query {
-        customers(filterSyntax : {
-                startSpan : "First",
-                matchCriteria : {
-                    countryCode : "AU",
-                    isoCodes : ["27B-34R", "95A-E23"],
-                    
-                }
-            }) {
-            name
-            associatedMetaData    
-        }
-    }
-    
-``` 
-   
-Note : The `JSON` scalar is a simple alias type to the `Object` scalar because often the returned data is a blob of JSON.  They are 
-all just objects at runtime in graphql-java terms and what network serialisation protocol is up to you.  Choose whichever name you think
-adds more semantic readers to your schema consumers. 
-
-
-## Numeric Scalars
-
-
-* `PositiveInt`
-  * An `Int` scalar that MUST be greater than zero   
-* `NegativeInt`
-  * An `Int` scalar that MUST be less than zero   
-* `NonPositiveInt`
-  * An `Int` scalar that MUST be less than or equal to zero   
-* `NonNegativeInt`
-  * An `Int` scalar that MUST be greater than or equal to zero   
-* `PositiveFloat`
-  * An `Float` scalar that MUST be greater than zero   
-* `NegativeFloat`
-  * An `Float` scalar that MUST be less than zero   
-* `NonPositiveFloat`
-  * An `Float` scalar that MUST be less than or equal to zero   
-* `NonNegativeFloat`
-  * An `Float` scalar that MUST be greater than or equal to zero   
-
-The numeric scalars are derivations of the standard graphql `Int` and `Float` scalars that enforce range limits.
-
-An example declaration in SDL might be:
-
-```graphql
-
-    type Customer {
-        name : String
-        currentHeight : PositiveInt
-        weightLossGoal : NonPositiveInt
-        averageWeightLoss : NegativeFloat
-    }
-    
-    type Query {
-        customers(height : PositiveInt) : [Customers]
-    }
-    
-``` 
-
-And example query might look like:
-
-```graphql
-    
-    query {
-        customers(height : 182) {
-            name
-            height
-            weightLossGoal    
-        }
-    }
-    
-``` 
-
-
-## Regex Scalars
-
-The RegexScalar has a builder where you provide one or more regex patterns that control the acceptable values
-for a new scalar.
-
-You name the scalar and it provides an implementation.
-
-For example, imagine a `phoneNumber` scalar like this :
-
-```java
-
-    RegexScalar phoneNumberScalar = ExtendedScalars.newRegexScalar("phoneNumber")
-            .addPattern(Pattern.compile("\\([0-9]*\\)[0-9]*"))
-            .build()
-
 ```
 
-## Locale Scalar
-
-The Locale scalar handles [IETF BCP 47](https://tools.ietf.org/html/bcp47) language tags via the 
-JDK method [Locale.forLanguageTag](https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html#forLanguageTag(java.lang.String))
+And use the scalar in your schema
 
 ```graphql
+scalar DateTime
+  @specifiedBy(url: "https://scalars.graphql.org/andimarek/date-time.html")
+type Something {
+  someDateTime: DateTime
+}
+```
 
-    type Customer {
-        name : String
-        locale : Locale
-    }
-    
-    type Query {
-        customers(inLocale : Locale) : [Customers]
-    }
-``` 
-
-An example query to look for customers in the Romanian locale might look like:
-
-```graphql
-    
-    query {
-        customers(inLocale : "ro-RO") {
-            name
-            locale
-        }
-    }
-    
-``` 
-## Country Code Scalar
-The CountryCode scalar type as defined by [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
-
-
-An example declaration in SDL might be:
-```graphql
-    scalar CountryCode
-
-    type Customer {
-      name : String
-      countryCode : CountryCode
-    }
-``` 
-
-And example query might look like:
-
-```graphql
-    query {
-       customers(code : "US") {
-                name
-                countryCode
-        }
-    }
-``` 
-## Currency Scalar
-
-A field whose value is an [ISO-4217](https://en.wikipedia.org/wiki/ISO_4217) currency.
-
-An example declaration in SDL might be:
-```graphql
-    scalar Currency
-
-    type Account {
-      id : String
-      currency : Currency
-      accountNumber: String
-    }
-``` 
-
-And example query might look like:
-
-```graphql
-    query {
-      accounts(currency : "USD") {
-        id
-        currency
-        accountNumber
-      }
-    }
-``` 
+# Custom Scalars
 
 ## Alias Scalars
 
-You can create aliases for existing scalars to add more semantic meaning to them.
+| Scalar Name     | Scalar Specification                           | Description                                                                       |
+| --------------- | ---------------------------------------------- | --------------------------------------------------------------------------------- |
+| `AliasedScalar` | <pre lang="graphql">scalar AliasedScalar</pre> | You can create aliases for existing scalars to add more semantic meaning to them. |
 
-For example a link to a social media post could be representing by a `String` but the name `SocialMediaLink` is a 
+For example a link to a social media post could be representing by a `String` but the name `SocialMediaLink` is a
 more semantically meaningful name for that scalar type.
 
 For example, you would build it like this:
@@ -337,35 +96,263 @@ For example, you would build it like this:
 And use it in a SDL schema like this :
 
 ```graphql
-
-     type Customer {
-           name : String
-           socialMediaLink : SocialMediaLink
-     }
-
+type Customer {
+  name: String
+  socialMediaLink: SocialMediaLink
+}
 ```
 
-Note: A future version of the graphql specification may add this capability but in the meantime you can use this facility.
+## Date & Time Scalars
+
+| Scalar Name | Scalar Definition                                                                                                                  | Description                                                                                                                                                    |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DateTime`  | <pre lang="graphql">scalar DateTime @specifiedBy(url: "https://scalars.graphql.org/andimarek/date-time.html")</pre lang="graphql"> | An RFC-3339 compliant date time scalar that accepts string values like `1996-12-19T16:39:57-08:00` and produces `java.time.OffsetDateTime` objects at runtime. |
+| `Time`      | <pre lang="graphql">scalar Time @specifiedBy(url: "https://tools.ietf.org/html/rfc3339")</pre>                                     | An RFC-3339 compliant time scalar that accepts string values like `16:39:57-08:00` and produces `java.time.OffsetTime` objects at runtime                      |
+| `LocalTime` | <pre lang="graphql">scalar LocalTime</pre>                                                                                         | 24-hour clock time string in the format `hh:mm:ss.sss` or `hh:mm:ss` if partial seconds is zero and produces `java.time.LocalTime` objects at runtime.         |
+| `Date`      | <pre lang="graphql">scalar Date @specifiedBy(url: "https://tools.ietf.org/html/rfc3339")</pre>                                     | An RFC-3339 compliant date scalar that accepts string values like `1996-12-19` and produces `java.time.LocalDate` objects at runtime                           |
+
+An example declaration in SDL might be:
+
+```graphql
+type Customer {
+  birthDay: Date
+  workStartTime: Time
+  bornAt: DateTime
+}
+
+type Query {
+  customers(bornAfter: DateTime): [Customers]
+}
+```
+
+And example query might look like:
+
+```graphql
+query {
+  customers(bornAfter: "1996-12-19T16:39:57-08:00") {
+    birthDay
+    bornAt
+  }
+}
+```
+
+## ID Scalars
+
+| Scalar Name | Scalar Definition                                                                              | Description                                                                                                                                                     |
+| ----------- | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `UUID`      | <pre lang="graphql">scalar UUID @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")</pre> | A universally unique identifier scalar that accepts uuid values like `2423f0a0-3b81-4115-a189-18df8b35e8fc` and produces `java.util.UUID` instances at runtime. |
+
+## Numeric Scalars
+
+| Scalar Name        | Scalar Definition                                 | Description                                                   |
+| ------------------ | ------------------------------------------------- | ------------------------------------------------------------- |
+| `PositiveInt`      | <pre lang="graphql">scalar PositiveInt</pre>      | An `Int` scalar that MUST be greater than zero.               |
+| `NegativeInt`      | <pre lang="graphql">scalar NegativeInt</pre>      | An `Int` scalar that MUST be less than zero.                  |
+| `NonPositiveInt`   | <pre lang="graphql">scalar NonPositiveInt</pre>   | An `Int` scalar that MUST be less than or equal to zero.      |
+| `NonNegativeInt`   | <pre lang="graphql">scalar NonNegativeInt</pre>   | An `Int` scalar that MUST be greater than or equal to zero.   |
+| `PositiveFloat`    | <pre lang="graphql">scalar PositiveFloat</pre>    | An `Float` scalar that MUST be greater than zero.             |
+| `NegativeFloat`    | <pre lang="graphql">scalar NegativeFloat</pre>    | An `Float` scalar that MUST be less than zero.                |
+| `NonPositiveFloat` | <pre lang="graphql">scalar NonPositiveFloat</pre> | An `Float` scalar that MUST be less than or equal to zero.    |
+| `NonNegativeFloat` | <pre lang="graphql">scalar NonNegativeFloat</pre> | An `Float` scalar that MUST be greater than or equal to zero. |
+
+The numeric scalars are derivations of the standard GraphQL `Int` and `Float` scalars that enforce range limits.
+
+An example declaration in SDL might be:
+
+```graphql
+type Customer {
+  name: String
+  currentHeight: PositiveInt
+  weightLossGoal: NonPositiveInt
+  averageWeightLoss: NegativeFloat
+}
+
+type Query {
+  customers(height: PositiveInt): [Customers]
+}
+```
+
+And example query might look like:
+
+```graphql
+query {
+  customers(height: 182) {
+    name
+    height
+    weightLossGoal
+  }
+}
+```
 
 ## Java Primitives
-* `GraphQLLong`
-  * A scalar which represents `java.lang.Long`
-* `GraphQLShort`
-  * A scalar which represents `java.lang.Short`
-* `GraphQLByte`
-  * A scalar which represents `java.lang.Byte`
-* `GraphQLBigDecimal`
-  * A scalar which represents `java.math.BigDecimal`
-* `GraphQLBigInteger`
-  * A scalar which represents `java.math.BigInteger`
-* `GraphQLChar`
-  * A scalar which represents `java.lang.Character`
 
+| Scalar Name         | Scalar Specification                               | Description                                      |
+| ------------------- | -------------------------------------------------- | ------------------------------------------------ |
+| `GraphQLLong`       | <pre lang="graphql">scalar GraphQLLong</pre>       | A scalar which represents `java.lang.Long`       |
+| `GraphQLShort`      | <pre lang="graphql">scalar GraphQLShort</pre>      | A scalar which represents `java.lang.Short`      |
+| `GraphQLByte`       | <pre lang="graphql">scalar GraphQLByte</pre>       | A scalar which represents `java.lang.Byte`       |
+| `GraphQLBigDecimal` | <pre lang="graphql">scalar GraphQLBigDecimal</pre> | A scalar which represents `java.math.BigDecimal` |
+| `GraphQLBigInteger` | <pre lang="graphql">scalar GraphQLBigInteger</pre> | A scalar which represents `java.math.BigInteger` |
+| `GraphQLChar`       | <pre lang="graphql">scalar GraphQLChar</pre>       | A scalar which represents `java.lang.Character`  |
 
-## Other Scalars
+## Locale Scalar
 
-* `Url`
-  * An url scalar that accepts string values like `https://www.w3.org/Addressing/URL/url-spec.txt` and produces 
-  `java.net.URL` objects at runtime  
-  
+| Scalar Name | Scalar Specification                                                                           | Description                                                                                                                                                                                                                             |
+| ----------- | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Locale`    | <pre lang="graphql">scalar Locale @specifiedBy(url: "https://tools.ietf.org/html/bcp47")</pre> | The Locale scalar handles [IETF BCP 47](https://tools.ietf.org/html/bcp47) language tags via the JDK method [Locale.forLanguageTag](<https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html#forLanguageTag(java.lang.String)>) |
 
+```graphql
+type Customer {
+  name: String
+  locale: Locale
+}
+
+type Query {
+  customers(inLocale: Locale): [Customers]
+}
+```
+
+An example query to look for customers in the Romanian locale might look like:
+
+```graphql
+query {
+  customers(inLocale: "ro-RO") {
+    name
+    locale
+  }
+}
+```
+
+## Country Code Scalar
+
+| Scalar Name   | Scalar Specification                         | Description                                                                                                       |
+| ------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `CountryCode` | <pre lang="graphql">scalar CountryCode</pre> | The CountryCode scalar type as defined by [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). |
+
+An example declaration in SDL might be:
+
+```graphql
+scalar CountryCode
+
+type Customer {
+  name: String
+  countryCode: CountryCode
+}
+```
+
+And example query might look like:
+
+```graphql
+query {
+  customers(code: "US") {
+    name
+    countryCode
+  }
+}
+```
+
+## Currency Scalar
+
+| Scalar Name | Scalar Specification                      | Description                                                                            |
+| ----------- | ----------------------------------------- | -------------------------------------------------------------------------------------- |
+| `Currency`  | <pre lang="graphql">scalar Currency</pre> | A field whose value is an [ISO-4217](https://en.wikipedia.org/wiki/ISO_4217) currency. |
+
+An example declaration in SDL might be:
+
+```graphql
+scalar Currency
+
+type Account {
+  id: String
+  currency: Currency
+  accountNumber: String
+}
+```
+
+And example query might look like:
+
+```graphql
+query {
+  accounts(currency: "USD") {
+    id
+    currency
+    accountNumber
+  }
+}
+```
+
+## URL Scalars
+
+| Scalar Name | Scalar Specification                                                                                     | Description                                                                                                                                    |
+| ----------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Url`       | <pre lang="graphql">scalar URL @specifiedBy(url: "https://www.w3.org/Addressing/URL/url-spec.txt")</pre> | An url scalar that accepts string values like `https://www.w3.org/Addressing/URL/url-spec.txt` and produces `java.net.URL` objects at runtime. |
+
+## Object / JSON Scalars
+
+| Scalar Name | Scalar Specification                    | Description                                                                     |
+| ----------- | --------------------------------------- | ------------------------------------------------------------------------------- |
+| `Object`    | <pre lang="graphql">scalar Object</pre> | An object scalar that accepts any object as a scalar value.                     |
+| `JSON`      | <pre lang="graphql">scalar JSON</pre>   | A synonym for the `Object` scalar, it will accept any object as a scalar value. |
+
+One of the design goals of GraphQL, is that the type system describes the shape of the data returned.
+
+The `Object` / `JSON` scalars work against this some what because they can return compound values outside the type system. As such
+they should be used sparingly. In general your should aim to describe the data via the GraphQL type system where you can and only
+resort to the `Object` / `JSON` scalars in very rare circumstances.
+
+An example might be an extensible GraphQL system where systems can input custom metadata objects that cant be known at
+schema type design time.
+
+An example declaration in SDL might be:
+
+```graphql
+type Customer {
+  name: String
+  associatedMetaData: JSON
+}
+
+type Query {
+  customers(filterSyntax: JSON): [Customers]
+}
+```
+
+And example query might look like:
+
+```graphql
+query {
+  customers(
+    filterSyntax: {
+      startSpan: "First"
+      matchCriteria: { countryCode: "AU", isoCodes: ["27B-34R", "95A-E23"] }
+    }
+  ) {
+    name
+    associatedMetaData
+  }
+}
+```
+
+Note : The `JSON` scalar is a simple alias type to the `Object` scalar because often the returned data is a blob of JSON. They are
+all just objects at runtime in `graphql-java` terms and what network serialization protocol is up to you. Choose whichever name you think
+adds more semantic readers to your schema consumers.
+
+## Regex Scalars
+
+| Scalar Name   | Scalar Specification | Description                                                                      |
+| ------------- | -------------------- | -------------------------------------------------------------------------------- |
+| `RegexScalar` | -                    | Allows you to build a new scalar via a builder pattern using regular expressions |
+
+The RegexScalar has a builder where you provide one or more regex patterns that control the acceptable values
+for a new scalar.
+
+You name the scalar and it provides an implementation.
+
+For example, imagine a `phoneNumber` scalar like this :
+
+```java
+
+    RegexScalar phoneNumberScalar = ExtendedScalars.newRegexScalar("phoneNumber")
+            .addPattern(Pattern.compile("\\([0-9]*\\)[0-9]*"))
+            .build()
+
+```

--- a/README.md
+++ b/README.md
@@ -287,23 +287,20 @@ query {
 ## URL Scalars
 
 <table>
-  <tr>
-    <td>Scalar Name</td>
-    <td>Scalar Specification</td>
-    <td>Description</td>
-  </tr>
-  <tr>
-    <td> `Url` </td>
-    <td>
-      <pre lang="graphql">
-      scalar URL
-        @specifiedBy(url: 
-          "https://www.w3.org/Addressing/URL/url-spec.txt"
-        )
-      </ore>
-    </td>
-    <td>An url scalar that accepts string values like `https://www.w3.org/Addressing/URL/url-spec.txt` and produces `java.net.URL` objects at runtime.</td>
-  </tr>
+<tr>
+<td>Scalar Name</td>
+<td>Scalar Specification</td>
+<td>Description</td>
+</tr>
+<tr>
+<td> `Url` </td>
+<td><pre lang="graphql">
+scalar URL
+@specifiedBy(url: "https://www.w3.org/Addressing/URL/url-spec.txt")
+</pre>
+</td>
+<td>An url scalar that accepts string values like `https://www.w3.org/Addressing/URL/url-spec.txt` and produces `java.net.URL` objects at runtime.</td>
+</tr>
 </table>
 
 | Scalar Name | Scalar Specification                                                                                     | Description                                                                                                                                    |

--- a/README.md
+++ b/README.md
@@ -120,12 +120,10 @@ type Customer {
 
 <table>
 <tr>
-<td>Scalar Name</td>
-<td>Scalar Specification</td>
+<td>Scalar</td>
 <td>Description</td>
 </tr>
 <tr>
-<td><code>DateTime</code></td>
 <td><pre lang="graphql">
 scalar DateTime
   @specifiedBy(url: 
@@ -135,7 +133,6 @@ scalar DateTime
 <td>A RFC-3339 compliant date time scalar that accepts string values like <code>1996-12-19T16:39:57-08:00</code> and produces <code>java.time.OffsetDateTime</code> objects at runtime.</td>
 </tr>
 <tr>
-<td><code>Date</code></td>
 <td><pre lang="graphql">
 scalar Date
   @specifiedBy(url: 
@@ -144,7 +141,6 @@ scalar Date
 <td>A RFC-3339 compliant date scalar that accepts string values like <code>1996-12-19</code> and produces <code>java.time.LocalDate</code> objects at runtime.</td>
 </tr>
 <tr>
-<td><code>Time</code></td>
 <td><pre lang="graphql">
 scalar Time
   @specifiedBy(url: 
@@ -154,7 +150,6 @@ scalar Time
 <td>A RFC-3339 compliant time scalar that accepts string values like <code>16:39:57-08:00</code> and produces <code>java.time.OffsetTime</code> objects at runtime.</td>
 </tr>
 <tr>
-<td><code>LocalTime</code></td>
 <td><pre lang="graphql">
 scalar LocalTime
 </pre></td>
@@ -191,12 +186,10 @@ query {
 
 <table>
 <tr>
-<td>Scalar Name</td>
-<td>Scalar Specification</td>
+<td>Scalar</td>
 <td>Description</td>
 </tr>
 <tr>
-<td><code>UUID</code></td>
 <td><pre lang="graphql">
 scalar UUID
   @specifiedBy(url: 
@@ -211,47 +204,38 @@ scalar UUID
 
 <table>
 <tr>
-<td>Scalar Name</td>
-<td>Scalar Specification</td>
+<td>Scalar</td>
 <td>Description</td>
 </tr>
 <tr>
-<td><code>PositiveInt</code></td>
 <td><pre lang="graphql">scalar PositiveInt</pre></td>
 <td>An <code>Int</code> scalar that MUST be greater than zero.</td>
 </tr>
 <tr>
-<td><code>NegativeInt</code></td>
 <td><pre lang="graphql">scalar NegativeInt</pre></td>
 <td>An <code>Int</code> scalar that MUST be less than zero.</td>
 </tr>
 <tr>
-<td><code>NonPositiveInt</code></td>
 <td><pre lang="graphql">scalar NonPositiveInt</pre></td>
 <td>An <code>Int</code> scalar that MUST be less than or equal to zero.</td>
 </tr>
 <tr>
-<td><code>NonNegativeInt</code></td>
 <td><pre lang="graphql">scalar NonNegativeInt</pre></td>
 <td>An <code>Int</code> scalar that MUST be greater than or equal to zero.</td>
 </tr>
 <tr>
-<td><code>PositiveFloat</code></td>
 <td><pre lang="graphql">scalar PositiveFloat</pre></td>
 <td>An <code>Float</code> scalar that MUST be greater than zero.</td>
 </tr>
 <tr>
-<td><code>NegativeFloat</code></td>
 <td><pre lang="graphql">scalar NegativeFloat</pre></td>
 <td>An <code>Float</code> scalar that MUST be less than zero.</td>
 </tr>
 <tr>
-<td><code>NonPositiveFloat</code></td>
 <td><pre lang="graphql">scalar NonPositiveFloat</pre></td>
 <td>An <code>Float</code> scalar that MUST be less than or equal to zero.</td>
 </tr>
 <tr>
-<td><code>NonNegativeFloat</code></td>
 <td><pre lang="graphql">scalar NonNegativeFloat</pre></td>
 <td>An <code>Float</code> scalar that MUST be greater than or equal to zero.</td>
 </tr>
@@ -290,37 +274,30 @@ query {
 
 <table>
 <tr>
-<td>Scalar Name</td>
-<td>Scalar Specification</td>
+<td>Scalar</td>
 <td>Description</td>
 </tr>
 <tr>
-<td><code>GraphQLLong</code></td>
 <td><pre lang="graphql">scalar GraphQLLong</pre></td>
 <td>A scalar which represents <code>java.lang.Long<code></td>
 </tr>
 <tr>
-<td><code>GraphQLShort</code></td>
 <td><pre lang="graphql">scalar GraphQLShort</pre></td>
 <td>A scalar which represents <code>java.lang.Short<code></td>
 </tr>
 <tr>
-<td><code>GraphQLByte</code></td>
 <td><pre lang="graphql">scalar GraphQLByte</pre></td>
 <td>A scalar which represents <code>java.lang.Byte<code></td>
 </tr>
 <tr>
-<td><code>GraphQLBigDecimal</code></td>
 <td><pre lang="graphql">scalar GraphQLBigDecimal</pre></td>
 <td>A scalar which represents <code>java.lang.BigDecimal<code></td>
 </tr>
 <tr>
-<td><code>GraphQLBigInteger</code></td>
 <td><pre lang="graphql">scalar GraphQLBigInteger</pre></td>
 <td>A scalar which represents <code>java.lang.BigInteger<code></td>
 </tr>
 <tr>
-<td><code>GraphQLChar</code></td>
 <td><pre lang="graphql">scalar GraphQLChar</pre></td>
 <td>A scalar which represents <code>java.lang.Character<code></td>
 </tr>
@@ -330,12 +307,10 @@ query {
 
 <table>
 <tr>
-<td>Scalar Name</td>
-<td>Scalar Specification</td>
+<td>Scalar</td>
 <td>Description</td>
 </tr>
 <tr>
-<td><code>Locale</code></td>
 <td><pre lang="graphql">
 scalar Locale
   @specifiedBy(url: 
@@ -372,12 +347,10 @@ query {
 
 <table>
 <tr>
-<td>Scalar Name</td>
-<td>Scalar Specification</td>
+<td>Scalar</td>
 <td>Description</td>
 </tr>
 <tr>
-<td><code>CountryCode</code></td>
 <td><pre lang="graphql">
 scalar CountryCode 
   @specifiedBy(url: 
@@ -414,12 +387,10 @@ query {
 
 <table>
 <tr>
-<td>Scalar Name</td>
-<td>Scalar Specification</td>
+<td>Scalar</td>
 <td>Description</td>
 </tr>
 <tr>
-<td><code>Currency</code></td>
 <td><pre lang="graphql">
 scalar Currency
   @specifiedBy(url: 
@@ -458,12 +429,10 @@ query {
 
 <table>
 <tr>
-<td>Scalar Name</td>
-<td>Scalar Specification</td>
+<td>Scalar</td>
 <td>Description</td>
 </tr>
 <tr>
-<td><code>Url</code></td>
 <td><pre lang="graphql">
 scalar URL
   @specifiedBy(url: 
@@ -478,17 +447,14 @@ scalar URL
 
 <table>
 <tr>
-<td>Scalar Name</td>
-<td>Scalar Specification</td>
+<td>Scalar</td>
 <td>Description</td>
 </tr>
 <tr>
-<td><code>Object</code></td>
 <td><pre lang="graphql">scalar Object</pre></td>
 <td>An object scalar that accepts any object as a scalar value.</td>
 </tr>
 <tr>
-<td><code>JSON</code></td>
 <td><pre lang="graphql">scalar JSON</pre></td>
 <td>A synonym for the `Object` scalar, it will accept any object as a scalar value.</td>
 </tr>
@@ -540,12 +506,10 @@ adds more semantic readers to your schema consumers.
 
 <table>
 <tr>
-<td>Scalar Name</td>
-<td>Scalar Specification</td>
+<td>Scalar</td>
 <td>Description</td>
 </tr>
 <tr>
-<td><code>RegexScalar</code></td>
 <td><pre lang="graphql">-</pre></td>
 <td>Allows you to build a new scalar via a builder pattern using regular expressions.</td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ scalar DateTime
 <td><pre lang="graphql">
 scalar Date
   @specifiedBy(url: 
-    ["https://tools.ietf.org/html/rfc3339](https://tools.ietf.org/html/rfc3339)"
+    "https://tools.ietf.org/html/rfc3339"
   )</pre></td>
 <td>A RFC-3339 compliant date scalar that accepts string values like <code>1996-12-19</code> and produces <code>java.time.LocalDate</code> objects at runtime.</td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ scalar Locale
     "https://tools.ietf.org/html/bcp47"
   )
 </pre></td>
-<td>The Locale scalar handles <a target="_blank" href="https://tools.ietf.org/html/bcp47">IETF BCP 47</a> language tags via the JDK method <a target="_blank" href="https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html#forLanguageTag(java.lang.String)">Locale.forLanguageTag</a>.</td>
+<td>The Locale scalar handles <a href="https://tools.ietf.org/html/bcp47">IETF BCP 47</a> language tags via the JDK method <a href="https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html#forLanguageTag(java.lang.String)">Locale.forLanguageTag</a>.</td>
 </tr>
 </table>
 
@@ -369,7 +369,7 @@ scalar CountryCode
     "https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2"
   )
 </pre></td>
-<td>The CountryCode scalar type as defined by <a target="_blank" href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a>.</td>
+<td>The CountryCode scalar type as defined by <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a>.</td>
 </tr>
 </table>
 
@@ -409,7 +409,7 @@ scalar Currency
     "https://en.wikipedia.org/wiki/ISO_4217"
   )
 </pre></td>
-<td>A field whose value is an <a target="_blank" href="https://en.wikipedia.org/wiki/ISO_4217">ISO-4217</a> currency.</td>
+<td>A field whose value is an <a href="https://en.wikipedia.org/wiki/ISO_4217">ISO-4217</a> currency.</td>
 </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ type Something {
 
 <table>
 <tr>
-<td>Scalar</td>
+<td>Scalar Definition</td>
 <td>Description</td>
 </tr>
 <tr>
@@ -118,7 +118,7 @@ type Customer {
 
 <table>
 <tr>
-<td>Scalar</td>
+<td>Scalar Definition</td>
 <td>Description</td>
 </tr>
 <tr>
@@ -184,7 +184,7 @@ query {
 
 <table>
 <tr>
-<td>Scalar</td>
+<td>Scalar Definition</td>
 <td>Description</td>
 </tr>
 <tr>
@@ -202,7 +202,7 @@ scalar UUID
 
 <table>
 <tr>
-<td>Scalar</td>
+<td>Scalar Definition</td>
 <td>Description</td>
 </tr>
 <tr>
@@ -272,7 +272,7 @@ query {
 
 <table>
 <tr>
-<td>Scalar</td>
+<td>Scalar Definition</td>
 <td>Description</td>
 </tr>
 <tr>
@@ -305,7 +305,7 @@ query {
 
 <table>
 <tr>
-<td>Scalar</td>
+<td>Scalar Definition</td>
 <td>Description</td>
 </tr>
 <tr>
@@ -345,7 +345,7 @@ query {
 
 <table>
 <tr>
-<td>Scalar</td>
+<td>Scalar Definition</td>
 <td>Description</td>
 </tr>
 <tr>
@@ -385,7 +385,7 @@ query {
 
 <table>
 <tr>
-<td>Scalar</td>
+<td>Scalar Definition</td>
 <td>Description</td>
 </tr>
 <tr>
@@ -427,7 +427,7 @@ query {
 
 <table>
 <tr>
-<td>Scalar</td>
+<td>Scalar Definition</td>
 <td>Description</td>
 </tr>
 <tr>
@@ -437,7 +437,7 @@ scalar URL
     "https://www.w3.org/Addressing/URL/url-spec.txt"
   )
 </pre></td>
-<td>An url scalar that accepts string values like `https://www.w3.org/Addressing/URL/url-spec.txt` and produces `java.net.URL` objects at runtime.</td>
+<td>An url scalar that accepts string values like `https://www.w3.org/Addressing/URL/url-spec.txt` and produces <code>java.net.URL</code> objects at runtime.</td>
 </tr>
 </table>
 
@@ -445,7 +445,7 @@ scalar URL
 
 <table>
 <tr>
-<td>Scalar</td>
+<td>Scalar Definition</td>
 <td>Description</td>
 </tr>
 <tr>
@@ -454,7 +454,7 @@ scalar URL
 </tr>
 <tr>
 <td><pre lang="graphql">scalar JSON</pre></td>
-<td>A synonym for the `Object` scalar, it will accept any object as a scalar value.</td>
+<td>A synonym for the <code>Object</code> scalar, it will accept any object as a scalar value.</td>
 </tr>
 </table>
 
@@ -504,11 +504,11 @@ adds more semantic readers to your schema consumers.
 
 <table>
 <tr>
-<td>Scalar</td>
+<td>Scalar Name</td>
 <td>Description</td>
 </tr>
 <tr>
-<td><pre lang="graphql">-</pre></td>
+<td><code>RegexScalar</code></td>
 <td>Allows you to build a new scalar via a builder pattern using regular expressions.</td>
 </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -24,15 +24,19 @@ You would use custom scalars when you want to describe more meaningful behavior 
 
 To use this library put the following into your gradle config
 
+```java
     implementation 'com.graphql-java:graphql-java-extended-scalars:20.0'
+```
 
 or the following into your Maven config
 
+```xml
     <dependency>
       <groupId>com.graphql-java</groupId>
       <artifactId>graphql-java-extended-scalars</artifactId>
       <version>20.0</version>
     </dependency>
+```
 
 > Note:
 >
@@ -67,6 +71,7 @@ And use the scalar in your schema
 ```graphql
 scalar DateTime
   @specifiedBy(url: "https://scalars.graphql.org/andimarek/date-time.html")
+
 type Something {
   someDateTime: DateTime
 }

--- a/README.md
+++ b/README.md
@@ -296,7 +296,9 @@ query {
 <td> `Url` </td>
 <td><pre lang="graphql">
 scalar URL
-@specifiedBy(url: "https://www.w3.org/Addressing/URL/url-spec.txt")
+  @specifiedBy(url: 
+    "https://www.w3.org/Addressing/URL/url-spec.txt"
+  )
 </ore>
 </td>
 <td>An url scalar that accepts string values like `https://www.w3.org/Addressing/URL/url-spec.txt` and produces `java.net.URL` objects at runtime.</td>

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ scalar UUID
     "https://tools.ietf.org/html/rfc4122"
   )
 </pre></td>
-<td>A universally unique identifier scalar that accepts uuid values like `2423f0a0-3b81-4115-a189-18df8b35e8fc` and produces `java.util.UUID` instances at runtime.</td>
+<td>A universally unique identifier scalar that accepts uuid values like <code>2423f0a0-3b81-4115-a189-18df8b35e8fc</code> and produces <code>java.util.UUID</code> instances at runtime.</td>
 </tr>
 </table>
 
@@ -451,7 +451,7 @@ scalar URL
     "https://www.w3.org/Addressing/URL/url-spec.txt"
   )
 </pre></td>
-<td>An url scalar that accepts string values like `https://www.w3.org/Addressing/URL/url-spec.txt` and produces <code>java.net.URL</code> objects at runtime.</td>
+<td>An url scalar that accepts string values like https://www.w3.org/Addressing/URL/url-spec.txt and produces <code>java.net.URL</code> objects at runtime.</td>
 </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -294,13 +294,10 @@ query {
 </tr>
 <tr>
 <td> `Url` </td>
-<td>
-
-````graphql
+<td><pre lang="graphql">
 scalar URL
 @specifiedBy(url: "https://www.w3.org/Addressing/URL/url-spec.txt")
-```
-
+</ore>
 </td>
 <td>An url scalar that accepts string values like `https://www.w3.org/Addressing/URL/url-spec.txt` and produces `java.net.URL` objects at runtime.</td>
 </tr>
@@ -337,7 +334,7 @@ type Customer {
 type Query {
   customers(filterSyntax: JSON): [Customers]
 }
-````
+```
 
 And example query might look like:
 

--- a/README.md
+++ b/README.md
@@ -83,12 +83,10 @@ type Something {
 
 <table>
 <tr>
-<td>Scalar Name</td>
-<td>Scalar Specification</td>
+<td>Scalar</td>
 <td>Description</td>
 </tr>
 <tr>
-<td><code>AliasedScalar</code></td>
 <td><pre lang="graphql">
 scalar AliasedScalar
 </pre></td>


### PR DESCRIPTION
Overhaul of the README structure.  

Main changes proposed are
* update links back to latest public graphql specification sections
* split out `how to use` section. include netflix dgs configuration documentation
* introduce `@specifiedBy` directive with link to specification
* convert each custom scalar entry from lists to a table
* add scalar definition with `@specifiedBy` where available. (_note: I had to use html instead of markdown in order to have code blocks within the table_)
* reorder of scalar entries to more logically group them