### PR TITLE
Downgrade to Java 8 ahead of v20.x release

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 11
+      - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: '11.0.17'
+          java-version: '8.0.282'
       - name: build test and publish
         run: ./gradlew assemble && ./gradlew check --info && ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -x check --info --stacktrace

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 11
+      - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: '11.0.17'
+          java-version: '8.0.282'
       - name: build and test
         run: ./gradlew assemble && ./gradlew check --info --stacktrace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 11
+      - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: '11.0.17'
+          java-version: '8.0.282'
       - name: build test and publish
         run: ./gradlew assemble && ./gradlew check --info && ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -x check --info --stacktrace

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,15 @@ plugins {
     id "biz.aQute.bnd.builder" version "6.4.0"
 }
 
+if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+    def msg = String.format("This build must be run with java 1.8 - you are running %s - gradle finds the JDK via JAVA_HOME=%s",
+            JavaVersion.current(), System.getenv("JAVA_HOME"))
+    throw new GradleException(msg)
+}
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
 def getDevelopmentVersion() {
     def output = new StringBuilder()
     def error = new StringBuilder()
@@ -25,17 +34,10 @@ def getDevelopmentVersion() {
     "0.0.0-" + new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date()) + "-" + gitHash
 }
 
-
 def releaseVersion = System.env.RELEASE_VERSION
 version = releaseVersion ? releaseVersion : getDevelopmentVersion()
 println "Building version = " + version
 group = 'com.graphql-java'
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
-    }
-}
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -31,20 +31,16 @@ version = releaseVersion ? releaseVersion : getDevelopmentVersion()
 println "Building version = " + version
 group = 'com.graphql-java'
 
-if (JavaVersion.current() != JavaVersion.VERSION_11) {
-    def msg = String.format("This build must be run with Java 11 - you are running %s - gradle finds the JDK via JAVA_HOME=%s",
-            JavaVersion.current(), System.getenv("JAVA_HOME"))
-    throw new GradleException(msg)
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
 }
-
-sourceCompatibility = JavaVersion.VERSION_11.toString()
-targetCompatibility = JavaVersion.VERSION_11.toString()
 
 repositories {
     mavenCentral()
     mavenLocal()
 }
-
 
 dependencies {
     compile "com.graphql-java:graphql-java:20.2"


### PR DESCRIPTION
Downgrading the Java version ahead of another v20 release. I'll bump this back up to Java 11 for v21 releases.

FYI I'll add the fancy toolchain later, we also need a Gradle update