### PR TITLE
 fix issue 126 - use MILLI_OF_SECOND

### DIFF
--- a/src/main/java/graphql/scalars/datetime/DateTimeScalar.java
+++ b/src/main/java/graphql/scalars/datetime/DateTimeScalar.java
@@ -125,7 +125,7 @@ public final class DateTimeScalar {
                 .appendValue(MINUTE_OF_HOUR, 2)
                 .appendLiteral(':')
                 .appendValue(SECOND_OF_MINUTE, 2)
-                .appendFraction(NANO_OF_SECOND, 3, 3, true)
+                .appendFraction(MILLI_OF_SECOND, 3, 3, true)
                 .appendOffset("+HH:MM", "Z")
                 .toFormatter();
     }


### PR DESCRIPTION
Fixed issue: https://github.com/graphql-java/graphql-java-extended-scalars/issues/126