### PR TITLE
Fixing name of UrlScalar

### DIFF
--- a/src/main/java/graphql/scalars/url/UrlScalar.java
+++ b/src/main/java/graphql/scalars/url/UrlScalar.java
@@ -87,8 +87,8 @@ public final class UrlScalar {
         };
 
         INSTANCE = GraphQLScalarType.newScalar()
-                .name("Url")
-                .description("A Url scalar")
+                .name("URL")
+                .description("A URL scalar")
                 .coercing(coercing)
                 .build();
     }


### PR DESCRIPTION
The README shows that there is a scalar named **URL**, but the implementation of the scalar is using **Url** as the name.  This causes an error when trying to declare and use the scalar like so:

```graphql
scalar URL
```

I can work around it, but this seems like a potential bug?  If not a bug, perhaps fixing the README would be appropriate?

```graphql
scalar Url
  @specifiedBy(url: 
    "https://www.w3.org/Addressing/URL/url-spec.txt"
  )
```

I also realize this would be a breaking change, so can certainly reject this PR.