### PR TITLE
Missing final for ExtendedScalars#UUID field

### DIFF
--- a/src/main/java/graphql/scalars/ExtendedScalars.java
+++ b/src/main/java/graphql/scalars/ExtendedScalars.java
@@ -154,7 +154,7 @@ public class ExtendedScalars {
      * A UUID scalar that accepts a universally unique identifier and produces {@link
      * java.util.UUID} objects at runtime.
      */
-    public static GraphQLScalarType UUID = UUIDScalar.INSTANCE;
+    public static final GraphQLScalarType UUID = UUIDScalar.INSTANCE;
 
     /**
      * An `Int` scalar that MUST be greater than zero


### PR DESCRIPTION
This one-line pr fixes an inconsistency issue with the use of final in ExtendedScalars.java, where the UUID field was missing it.

The final modified was added to all fields in pr https://github.com/graphql-java/graphql-java-extended-scalars/pull/53
However, when that pr was created the UUID scalar did not exists. It was [added later](https://github.com/graphql-java/graphql-java-extended-scalars/commit/ea81b1f8440b79bf185e0a39108843c96b4ebccc), but the pr author did not noticed (and github didn't notify) so when it was finally [merged](https://github.com/graphql-java/graphql-java-extended-scalars/commit/ff3865b84462ab9808f76a73f5736a5d016beacd#diff-6b65f355b16685a3a082a710f60f971b2baae281f0a3191c5b72b3f85ffb22dfR145), this single change was missing