### PR TITLE
This removes all the deprecated Coercing methods and replaces them with the desired ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,22 @@ scalar LocalTime
 </pre></td>
 <td>24-hour clock time string in the format <code>hh:mm:ss.sss</code> or <code>hh:mm:ss</code> if partial seconds is zero and produces <code>java.time.LocalTime</code> objects at runtime.</td>
 </tr>
+<tr>
+<td><pre lang="graphql">
+scalar SecondsSinceEpoch
+</pre></td>
+<td>A scalar that represents a point in time as seconds since the Unix epoch (January 1, 1970, 00:00:00 UTC). It accepts integers or strings containing integers as input values and produces <code>java.time.ZonedDateTime</code> objects at runtime (with UTC timezone).<br><br>
+Using seconds since epoch is preferable to formatted date time strings in several scenarios:
+<ul>
+<li>When you need a universal representation of a point in time that is timezone-agnostic</li>
+<li>For easier date/time arithmetic and comparison operations</li>
+<li>When storage space or bandwidth efficiency is important (more compact representation)</li>
+<li>To avoid complexities with different date formats and timezone conversions</li>
+<li>For better interoperability with systems that natively work with Unix timestamps</li>
+<li>When working with time-series data or logging systems where timestamps are commonly used</li>
+</ul>
+However, human readability is sacrificed compared to formatted date strings, so consider your use case requirements when choosing between <code>DateTime</code> and <code>SecondsSinceEpoch</code>.</td>
+</tr>
 </table>
 
 An example declaration in SDL might be:
@@ -181,10 +197,11 @@ type Customer {
   birthDay: Date
   workStartTime: Time
   bornAt: DateTime
+  createdAtTimestamp: SecondsSinceEpoch
 }
 
 type Query {
-  customers(bornAfter: DateTime): [Customers]
+  customers(bornAfter: DateTime, createdAfter: SecondsSinceEpoch): [Customers]
 }
 ```
 
@@ -192,9 +209,10 @@ And example query might look like:
 
 ```graphql
 query {
-  customers(bornAfter: "1996-12-19T16:39:57-08:00") {
+  customers(bornAfter: "1996-12-19T16:39:57-08:00", createdAfter: 1609459200) {
     birthDay
     bornAt
+    createdAtTimestamp
   }
 }
 ```

--- a/src/main/java/graphql/scalars/ExtendedScalars.java
+++ b/src/main/java/graphql/scalars/ExtendedScalars.java
@@ -10,6 +10,7 @@ import graphql.scalars.datetime.DateTimeScalar;
 import graphql.scalars.datetime.AccurateDurationScalar;
 import graphql.scalars.datetime.LocalTimeCoercing;
 import graphql.scalars.datetime.NominalDurationScalar;
+import graphql.scalars.datetime.SecondsSinceEpochScalar;
 import graphql.scalars.datetime.TimeScalar;
 import graphql.scalars.datetime.YearMonthScalar;
 import graphql.scalars.datetime.YearScalar;
@@ -137,6 +138,34 @@ public class ExtendedScalars {
      * @see java.time.Period
      */
     public static final GraphQLScalarType NominalDuration = NominalDurationScalar.INSTANCE;
+
+    /**
+     * A scalar that represents a point in time as seconds since the Unix epoch (Unix timestamp).
+     * <p>
+     * It accepts integers or strings containing integers as input values and produces
+     * `java.time.ZonedDateTime` objects at runtime (with UTC timezone).
+     * <p>
+     * Its {@link graphql.schema.Coercing#serialize(java.lang.Object)} method accepts various
+     * {@link java.time.temporal.TemporalAccessor} types and returns the number of seconds since epoch
+     * (January 1, 1970, 00:00:00 UTC).
+     * <p>
+     * Using seconds since epoch is preferable to formatted date time strings in several scenarios:
+     * <ul>
+     * <li>When you need a universal representation of a point in time that is timezone-agnostic</li>
+     * <li>For easier date/time arithmetic and comparison operations</li>
+     * <li>When storage space or bandwidth efficiency is important (more compact representation)</li>
+     * <li>To avoid complexities with different date formats and timezone conversions</li>
+     * <li>For better interoperability with systems that natively work with Unix timestamps</li>
+     * <li>When working with time-series data or logging systems where timestamps are commonly used</li>
+     * </ul>
+     * <p>
+     * However, human readability is sacrificed compared to formatted date strings, so consider your use case
+     * requirements when choosing between {@link #DateTime} and {@link #SecondsSinceEpoch}.
+     *
+     * @see java.time.Instant
+     * @see java.time.ZonedDateTime
+     */
+    public static final GraphQLScalarType SecondsSinceEpoch = SecondsSinceEpochScalar.INSTANCE;
 
     /**
      * An object scalar allows you to have a multi level data value without defining it in the graphql schema.

--- a/src/main/java/graphql/scalars/alias/AliasedScalar.java
+++ b/src/main/java/graphql/scalars/alias/AliasedScalar.java
@@ -1,7 +1,9 @@
 package graphql.scalars.alias;
 
 import graphql.Assert;
+import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.execution.CoercedVariables;
 import graphql.language.Value;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
@@ -9,7 +11,7 @@ import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
 
-import java.util.Map;
+import java.util.Locale;
 
 /**
  * Access this via {@link graphql.scalars.ExtendedScalars#newAliasedScalar(String)}
@@ -17,7 +19,8 @@ import java.util.Map;
 @Internal
 public final class AliasedScalar {
 
-    private AliasedScalar() {}
+    private AliasedScalar() {
+    }
 
     /**
      * A builder for {@link graphql.scalars.alias.AliasedScalar}
@@ -75,31 +78,25 @@ public final class AliasedScalar {
 
     private static GraphQLScalarType aliasedScalarImpl(String name, String description, GraphQLScalarType aliasedScalar) {
         Assert.assertNotNull(aliasedScalar);
-        Coercing<Object, Object> coercing = new Coercing<Object, Object>() {
+        Coercing<Object, Object> coercing = new Coercing<>() {
             @Override
-            public Object serialize(Object input) throws CoercingSerializeException {
-                return aliasedScalar.getCoercing().serialize(input);
+            public Object serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
+                return aliasedScalar.getCoercing().serialize(input, graphQLContext, locale);
             }
 
             @Override
-            public Object parseValue(Object input) throws CoercingParseValueException {
-                return aliasedScalar.getCoercing().parseValue(input);
+            public Object parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
+                return aliasedScalar.getCoercing().parseValue(input, graphQLContext, locale);
             }
 
             @Override
-            public Object parseLiteral(Object input) throws CoercingParseLiteralException {
-                return aliasedScalar.getCoercing().parseLiteral(input);
+            public Object parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
+                return aliasedScalar.getCoercing().parseLiteral(input, variables, graphQLContext, locale);
             }
 
             @Override
-            public Object parseLiteral(Object input, Map<String, Object> variables) throws CoercingParseLiteralException {
-                Coercing<?, ?> c = aliasedScalar.getCoercing();
-                return c.parseLiteral(input, variables);
-            }
-
-            @Override
-            public Value<?> valueToLiteral(Object input) {
-                return aliasedScalar.getCoercing().valueToLiteral(input);
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+                return aliasedScalar.getCoercing().valueToLiteral(input, graphQLContext, locale);
             }
         };
         return GraphQLScalarType.newScalar()

--- a/src/main/java/graphql/scalars/color/hex/HexColorCodeScalar.java
+++ b/src/main/java/graphql/scalars/color/hex/HexColorCodeScalar.java
@@ -1,14 +1,22 @@
 package graphql.scalars.color.hex;
 
+import graphql.GraphQLContext;
+import graphql.execution.CoercedVariables;
 import graphql.language.StringValue;
 import graphql.language.Value;
-import graphql.schema.*;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+import graphql.schema.GraphQLScalarType;
 
 import java.awt.*;
+import java.util.Locale;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import static graphql.scalars.util.Kit.typeName;
+
 /**
  * Access this via {@link graphql.scalars.ExtendedScalars#HexColorCode}
  * See the <a href="https://en.wikipedia.org/wiki/Web_colors">Web colors</a> for more details.
@@ -21,15 +29,15 @@ public class HexColorCodeScalar {
 
 
     static {
-        Coercing<Color, String> coercing = new Coercing<Color, String>() {
+        Coercing<Color, String> coercing = new Coercing<>() {
 
             private final Pattern HEX_PATTERN = Pattern.compile("^(#([A-Fa-f0-9]{3,4}){1,2})$");
 
             @Override
-            public String serialize(Object input) throws CoercingSerializeException {
+            public String serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 Color color = parseColor(input, CoercingSerializeException::new);
                 boolean hasAlpha = color.getAlpha() != 255;
-                if (hasAlpha){
+                if (hasAlpha) {
                     return String.format("#%02x%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue(), color.getAlpha());
                 } else {
                     return String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
@@ -37,12 +45,12 @@ public class HexColorCodeScalar {
             }
 
             @Override
-            public Color parseValue(Object input) throws CoercingParseValueException {
+            public Color parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 return parseColor(input, CoercingParseValueException::new);
             }
 
             @Override
-            public Color parseLiteral(Object input) throws CoercingParseLiteralException {
+            public Color parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (!(input instanceof StringValue)) {
                     throw new CoercingParseLiteralException("Expected type 'StringValue' but was '" + typeName(input) + "'.");
                 }
@@ -51,8 +59,8 @@ public class HexColorCodeScalar {
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
-                String s = serialize(input);
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+                String s = serialize(input, graphQLContext, locale);
                 return StringValue.newStringValue(s).build();
             }
 

--- a/src/main/java/graphql/scalars/country/code/CountryCodeScalar.java
+++ b/src/main/java/graphql/scalars/country/code/CountryCodeScalar.java
@@ -1,10 +1,17 @@
 package graphql.scalars.country.code;
 
+import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.execution.CoercedVariables;
 import graphql.language.StringValue;
 import graphql.language.Value;
-import graphql.schema.*;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+import graphql.schema.GraphQLScalarType;
 
+import java.util.Locale;
 import java.util.function.Function;
 
 import static graphql.scalars.util.Kit.typeName;
@@ -18,21 +25,21 @@ public class CountryCodeScalar {
     public static final GraphQLScalarType INSTANCE;
 
     static {
-        Coercing<CountryCode, String> coercing = new Coercing<CountryCode, String>() {
+        Coercing<CountryCode, String> coercing = new Coercing<>() {
 
             @Override
-            public String serialize(Object input) throws CoercingSerializeException {
+            public String serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 CountryCode countryCode = parseCountryCode(input, CoercingParseValueException::new);
                 return countryCode.name();
             }
 
             @Override
-            public CountryCode parseValue(Object input) throws CoercingParseValueException {
+            public CountryCode parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 return parseCountryCode(input, CoercingParseValueException::new);
             }
 
             @Override
-            public CountryCode parseLiteral(Object input) throws CoercingParseLiteralException {
+            public CountryCode parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (!(input instanceof StringValue)) {
                     throw new CoercingParseLiteralException("Expected AST type 'StringValue' but was '" + typeName(input) + "'.");
                 }
@@ -42,8 +49,8 @@ public class CountryCodeScalar {
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
-                String s = serialize(input);
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+                String s = serialize(input, graphQLContext, locale);
                 return StringValue.newStringValue(s).build();
             }
 

--- a/src/main/java/graphql/scalars/currency/CurrencyScalar.java
+++ b/src/main/java/graphql/scalars/currency/CurrencyScalar.java
@@ -1,11 +1,18 @@
 package graphql.scalars.currency;
 
+import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.execution.CoercedVariables;
 import graphql.language.StringValue;
 import graphql.language.Value;
-import graphql.schema.*;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+import graphql.schema.GraphQLScalarType;
 
 import java.util.Currency;
+import java.util.Locale;
 import java.util.function.Function;
 
 import static graphql.scalars.util.Kit.typeName;
@@ -19,21 +26,21 @@ public class CurrencyScalar {
     public static final GraphQLScalarType INSTANCE;
 
     static {
-        Coercing<Currency, String> coercing = new Coercing<Currency, String>() {
+        Coercing<Currency, String> coercing = new Coercing<>() {
             @Override
-            public String serialize(Object input) throws CoercingSerializeException {
+            public String serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 Currency currency = parseCurrency(input, CoercingSerializeException::new);
                 return currency.getCurrencyCode();
             }
 
             @Override
-            public Currency parseValue(Object input) throws CoercingParseValueException {
+            public Currency parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 return parseCurrency(input, CoercingParseValueException::new);
             }
 
 
             @Override
-            public Currency parseLiteral(Object input) throws CoercingParseLiteralException {
+            public Currency parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (!(input instanceof StringValue)) {
                     throw new CoercingParseLiteralException("Expected AST type 'StringValue' but was '" + typeName(input) + "'.");
                 }
@@ -42,8 +49,8 @@ public class CurrencyScalar {
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
-                String serializedInput = serialize(input);
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+                String serializedInput = serialize(input, graphQLContext, locale);
                 return StringValue.newStringValue(serializedInput).build();
             }
 

--- a/src/main/java/graphql/scalars/datetime/AccurateDurationScalar.java
+++ b/src/main/java/graphql/scalars/datetime/AccurateDurationScalar.java
@@ -1,6 +1,8 @@
 package graphql.scalars.datetime;
 
+import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.execution.CoercedVariables;
 import graphql.language.StringValue;
 import graphql.language.Value;
 import graphql.schema.Coercing;
@@ -11,6 +13,7 @@ import graphql.schema.GraphQLScalarType;
 
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
+import java.util.Locale;
 import java.util.function.Function;
 
 import static graphql.scalars.util.Kit.typeName;
@@ -23,12 +26,13 @@ public class AccurateDurationScalar {
 
     public static final GraphQLScalarType INSTANCE;
 
-    private AccurateDurationScalar() {}
+    private AccurateDurationScalar() {
+    }
 
     static {
-        Coercing<Duration, String> coercing = new Coercing<Duration, String>() {
+        Coercing<Duration, String> coercing = new Coercing<>() {
             @Override
-            public String serialize(Object input) throws CoercingSerializeException {
+            public String serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 Duration duration;
                 if (input instanceof Duration) {
                     duration = (Duration) input;
@@ -36,14 +40,14 @@ public class AccurateDurationScalar {
                     duration = parseDuration(input.toString(), CoercingSerializeException::new);
                 } else {
                     throw new CoercingSerializeException(
-                        "Expected something we can convert to 'java.time.Duration' but was '" + typeName(input) + "'."
+                            "Expected something we can convert to 'java.time.Duration' but was '" + typeName(input) + "'."
                     );
                 }
                 return duration.toString();
             }
 
             @Override
-            public Duration parseValue(Object input) throws CoercingParseValueException {
+            public Duration parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 Duration duration;
                 if (input instanceof Duration) {
                     duration = (Duration) input;
@@ -51,25 +55,25 @@ public class AccurateDurationScalar {
                     duration = parseDuration(input.toString(), CoercingParseValueException::new);
                 } else {
                     throw new CoercingParseValueException(
-                        "Expected a 'String' but was '" + typeName(input) + "'."
+                            "Expected a 'String' but was '" + typeName(input) + "'."
                     );
                 }
                 return duration;
             }
 
             @Override
-            public Duration parseLiteral(Object input) throws CoercingParseLiteralException {
+            public Duration parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (!(input instanceof StringValue)) {
                     throw new CoercingParseLiteralException(
-                        "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
+                            "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
                     );
                 }
                 return parseDuration(((StringValue) input).getValue(), CoercingParseLiteralException::new);
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
-                String s = serialize(input);
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+                String s = serialize(input, graphQLContext, locale);
                 return StringValue.newStringValue(s).build();
             }
 
@@ -83,11 +87,11 @@ public class AccurateDurationScalar {
         };
 
         INSTANCE = GraphQLScalarType.newScalar()
-            .name("AccurateDuration")
-            .description("A ISO 8601 duration scalar with only day, hour, minute, second components.")
-            .specifiedByUrl("https://scalars.graphql.org/AlexandreCarlton/accurate-duration") // TODO: Change to .specifiedByURL when builder added to graphql-java
-            .coercing(coercing)
-            .build();
+                .name("AccurateDuration")
+                .description("A ISO 8601 duration scalar with only day, hour, minute, second components.")
+                .specifiedByUrl("https://scalars.graphql.org/AlexandreCarlton/accurate-duration") // TODO: Change to .specifiedByURL when builder added to graphql-java
+                .coercing(coercing)
+                .build();
     }
 
 }

--- a/src/main/java/graphql/scalars/datetime/DateScalar.java
+++ b/src/main/java/graphql/scalars/datetime/DateScalar.java
@@ -1,6 +1,8 @@
 package graphql.scalars.datetime;
 
+import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.execution.CoercedVariables;
 import graphql.language.StringValue;
 import graphql.language.Value;
 import graphql.schema.Coercing;
@@ -14,6 +16,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
+import java.util.Locale;
 import java.util.function.Function;
 
 import static graphql.scalars.util.Kit.typeName;
@@ -22,18 +25,19 @@ import static graphql.scalars.util.Kit.typeName;
  * Access this via {@link graphql.scalars.ExtendedScalars#Date}
  */
 @Internal
-public final class DateScalar  {
+public final class DateScalar {
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
     public static final GraphQLScalarType INSTANCE;
 
-    private DateScalar() {}
+    private DateScalar() {
+    }
 
     static {
-        Coercing<LocalDate, String> coercing = new Coercing<LocalDate, String>() {
+        Coercing<LocalDate, String> coercing = new Coercing<>() {
             @Override
-            public String serialize(Object input) throws CoercingSerializeException {
+            public String serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 TemporalAccessor temporalAccessor;
                 if (input instanceof TemporalAccessor) {
                     temporalAccessor = (TemporalAccessor) input;
@@ -54,7 +58,7 @@ public final class DateScalar  {
             }
 
             @Override
-            public LocalDate parseValue(Object input) throws CoercingParseValueException {
+            public LocalDate parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 TemporalAccessor temporalAccessor;
                 if (input instanceof TemporalAccessor) {
                     temporalAccessor = (TemporalAccessor) input;
@@ -75,7 +79,7 @@ public final class DateScalar  {
             }
 
             @Override
-            public LocalDate parseLiteral(Object input) throws CoercingParseLiteralException {
+            public LocalDate parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (!(input instanceof StringValue)) {
                     throw new CoercingParseLiteralException(
                             "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
@@ -85,8 +89,8 @@ public final class DateScalar  {
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
-                String s = serialize(input);
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+                String s = serialize(input, graphQLContext, locale);
                 return StringValue.newStringValue(s).build();
             }
 

--- a/src/main/java/graphql/scalars/datetime/DateTimeScalar.java
+++ b/src/main/java/graphql/scalars/datetime/DateTimeScalar.java
@@ -1,6 +1,8 @@
 package graphql.scalars.datetime;
 
+import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.execution.CoercedVariables;
 import graphql.language.StringValue;
 import graphql.language.Value;
 import graphql.schema.Coercing;
@@ -15,6 +17,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.util.Locale;
 import java.util.function.Function;
 
 import static graphql.scalars.util.Kit.typeName;
@@ -33,13 +36,15 @@ public final class DateTimeScalar {
 
     public static final GraphQLScalarType INSTANCE;
 
-    private DateTimeScalar() {}
+    private DateTimeScalar() {
+    }
+
     private static final DateTimeFormatter customOutputFormatter = getCustomDateTimeFormatter();
 
     static {
-        Coercing<OffsetDateTime, String> coercing = new Coercing<OffsetDateTime, String>() {
+        Coercing<OffsetDateTime, String> coercing = new Coercing<>() {
             @Override
-            public String serialize(Object input) throws CoercingSerializeException {
+            public String serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 OffsetDateTime offsetDateTime;
                 if (input instanceof OffsetDateTime) {
                     offsetDateTime = (OffsetDateTime) input;
@@ -62,7 +67,7 @@ public final class DateTimeScalar {
             }
 
             @Override
-            public OffsetDateTime parseValue(Object input) throws CoercingParseValueException {
+            public OffsetDateTime parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 OffsetDateTime offsetDateTime;
                 if (input instanceof OffsetDateTime) {
                     offsetDateTime = (OffsetDateTime) input;
@@ -79,7 +84,7 @@ public final class DateTimeScalar {
             }
 
             @Override
-            public OffsetDateTime parseLiteral(Object input) throws CoercingParseLiteralException {
+            public OffsetDateTime parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (!(input instanceof StringValue)) {
                     throw new CoercingParseLiteralException(
                             "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
@@ -89,8 +94,8 @@ public final class DateTimeScalar {
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
-                String s = serialize(input);
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+                String s = serialize(input, graphQLContext, locale);
                 return StringValue.newStringValue(s).build();
             }
 

--- a/src/main/java/graphql/scalars/datetime/LocalTimeCoercing.java
+++ b/src/main/java/graphql/scalars/datetime/LocalTimeCoercing.java
@@ -1,6 +1,9 @@
 package graphql.scalars.datetime;
 
+import graphql.GraphQLContext;
+import graphql.execution.CoercedVariables;
 import graphql.language.StringValue;
+import graphql.language.Value;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
@@ -11,6 +14,7 @@ import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
+import java.util.Locale;
 import java.util.function.Function;
 
 import static graphql.scalars.util.Kit.typeName;
@@ -20,7 +24,7 @@ public class LocalTimeCoercing implements Coercing<LocalTime, String> {
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_TIME;
 
     @Override
-    public String serialize(final Object input) throws CoercingSerializeException {
+    public String serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
         TemporalAccessor temporalAccessor;
         if (input instanceof TemporalAccessor) {
             temporalAccessor = (TemporalAccessor) input;
@@ -41,7 +45,7 @@ public class LocalTimeCoercing implements Coercing<LocalTime, String> {
     }
 
     @Override
-    public LocalTime parseValue(final Object input) throws CoercingParseValueException {
+    public LocalTime parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
         TemporalAccessor temporalAccessor;
         if (input instanceof TemporalAccessor) {
             temporalAccessor = (TemporalAccessor) input;
@@ -62,13 +66,19 @@ public class LocalTimeCoercing implements Coercing<LocalTime, String> {
     }
 
     @Override
-    public LocalTime parseLiteral(final Object input) throws CoercingParseLiteralException {
+    public LocalTime parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
         if (!(input instanceof StringValue)) {
             throw new CoercingParseLiteralException(
                     "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
             );
         }
         return parseTime(((StringValue) input).getValue(), CoercingParseLiteralException::new);
+    }
+
+    @Override
+    public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+        String s = serialize(input, graphQLContext, locale);
+        return StringValue.newStringValue(s).build();
     }
 
     private static LocalTime parseTime(String s, Function<String, RuntimeException> exceptionMaker) {

--- a/src/main/java/graphql/scalars/datetime/NominalDurationScalar.java
+++ b/src/main/java/graphql/scalars/datetime/NominalDurationScalar.java
@@ -1,6 +1,8 @@
 package graphql.scalars.datetime;
 
+import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.execution.CoercedVariables;
 import graphql.language.StringValue;
 import graphql.language.Value;
 import graphql.schema.Coercing;
@@ -11,6 +13,7 @@ import graphql.schema.GraphQLScalarType;
 
 import java.time.Period;
 import java.time.format.DateTimeParseException;
+import java.util.Locale;
 import java.util.function.Function;
 
 import static graphql.scalars.util.Kit.typeName;
@@ -23,12 +26,13 @@ public class NominalDurationScalar {
 
     public static final GraphQLScalarType INSTANCE;
 
-    private NominalDurationScalar() {}
+    private NominalDurationScalar() {
+    }
 
     static {
-        Coercing<Period, String> coercing = new Coercing<Period, String>() {
+        Coercing<Period, String> coercing = new Coercing<>() {
             @Override
-            public String serialize(Object input) throws CoercingSerializeException {
+            public String serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 Period period;
                 if (input instanceof Period) {
                     period = (Period) input;
@@ -36,14 +40,14 @@ public class NominalDurationScalar {
                     period = parsePeriod(input.toString(), CoercingSerializeException::new);
                 } else {
                     throw new CoercingSerializeException(
-                        "Expected something we can convert to 'java.time.OffsetDateTime' but was '" + typeName(input) + "'."
+                            "Expected something we can convert to 'java.time.OffsetDateTime' but was '" + typeName(input) + "'."
                     );
                 }
                 return period.toString();
             }
 
             @Override
-            public Period parseValue(Object input) throws CoercingParseValueException {
+            public Period parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 Period period;
                 if (input instanceof Period) {
                     period = (Period) input;
@@ -51,25 +55,25 @@ public class NominalDurationScalar {
                     period = parsePeriod(input.toString(), CoercingParseValueException::new);
                 } else {
                     throw new CoercingParseValueException(
-                        "Expected a 'String' but was '" + typeName(input) + "'."
+                            "Expected a 'String' but was '" + typeName(input) + "'."
                     );
                 }
                 return period;
             }
 
             @Override
-            public Period parseLiteral(Object input) throws CoercingParseLiteralException {
+            public Period parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (!(input instanceof StringValue)) {
                     throw new CoercingParseLiteralException(
-                        "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
+                            "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
                     );
                 }
                 return parsePeriod(((StringValue) input).getValue(), CoercingParseLiteralException::new);
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
-                String s = serialize(input);
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+                String s = serialize(input, graphQLContext, locale);
                 return StringValue.newStringValue(s).build();
             }
 
@@ -83,10 +87,10 @@ public class NominalDurationScalar {
         };
 
         INSTANCE = GraphQLScalarType.newScalar()
-            .name("NominalDuration")
-            .description("A ISO 8601 duration with only year, month, week and day components.")
-            .specifiedByUrl("https://scalars.graphql.org/AlexandreCarlton/nominal-duration") // TODO: Change to .specifiedByURL when builder added to graphql-java
-            .coercing(coercing)
-            .build();
+                .name("NominalDuration")
+                .description("A ISO 8601 duration with only year, month, week and day components.")
+                .specifiedByUrl("https://scalars.graphql.org/AlexandreCarlton/nominal-duration") // TODO: Change to .specifiedByURL when builder added to graphql-java
+                .coercing(coercing)
+                .build();
     }
 }

--- a/src/main/java/graphql/scalars/datetime/SecondsSinceEpochScalar.java
+++ b/src/main/java/graphql/scalars/datetime/SecondsSinceEpochScalar.java
@@ -1,0 +1,176 @@
+package graphql.scalars.datetime;
+
+import graphql.GraphQLContext;
+import graphql.Internal;
+import graphql.execution.CoercedVariables;
+import graphql.language.IntValue;
+import graphql.language.StringValue;
+import graphql.language.Value;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+import graphql.schema.GraphQLScalarType;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAccessor;
+import java.util.Locale;
+
+import static graphql.scalars.util.Kit.typeName;
+
+/**
+ * Access this via {@link graphql.scalars.ExtendedScalars#SecondsSinceEpoch}
+ */
+@Internal
+public final class SecondsSinceEpochScalar {
+
+    public static final GraphQLScalarType INSTANCE;
+
+    private SecondsSinceEpochScalar() {
+    }
+
+    private static Temporal convertToTemporal(String value) {
+        try {
+            if (value.matches("\\d+")) {
+                long epochSeconds = Long.parseLong(value);
+                return convertEpochSecondsToTemporal(epochSeconds);
+            }
+            throw new CoercingParseValueException(
+                    "Invalid seconds since epoch value : '" + value + "'. Expected a string containing only digits."
+            );
+        } catch (Exception e) {
+            throw new CoercingParseValueException(
+                    "Invalid seconds since epoch value : '" + value + "'. " + e.getMessage()
+            );
+        }
+    }
+
+    private static Temporal convertEpochSecondsToTemporal(long epochSeconds) {
+        return Instant.ofEpochSecond(epochSeconds).atZone(ZoneOffset.UTC);
+    }
+
+    static {
+        Coercing<TemporalAccessor, Long> coercing = new Coercing<>() {
+            @Override
+            public Long serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
+                try {
+                    if (input instanceof Number) {
+                        Number number = (Number) input;
+                        return number.longValue();
+                    }
+                    if (input instanceof String) {
+                        try {
+                            return Long.parseLong((String) input);
+                        } catch (NumberFormatException e) {
+                            throw new CoercingSerializeException(
+                                    "Invalid seconds since epoch value : '" + input + "'. Expected a string containing only digits.",
+                                    e
+                            );
+                        }
+                    }
+                    if (input instanceof TemporalAccessor) {
+                        TemporalAccessor temporalAccessor = (TemporalAccessor) input;
+                        if (temporalAccessor instanceof Instant) {
+                            Instant instant = (Instant) temporalAccessor;
+                            return instant.getEpochSecond();
+                        } else if (temporalAccessor instanceof LocalDateTime) {
+                            LocalDateTime localDateTime = (LocalDateTime) temporalAccessor;
+                            return localDateTime.toEpochSecond(ZoneOffset.UTC);
+                        } else if (temporalAccessor instanceof ZonedDateTime) {
+                            ZonedDateTime zonedDateTime = (ZonedDateTime) temporalAccessor;
+                            return zonedDateTime.toEpochSecond();
+                        } else if (temporalAccessor instanceof OffsetDateTime) {
+                            OffsetDateTime offsetDateTime = (OffsetDateTime) temporalAccessor;
+                            return offsetDateTime.toEpochSecond();
+                        } else {
+                            try {
+                                Instant instant = Instant.from(temporalAccessor);
+                                return instant.getEpochSecond();
+                            } catch (Exception e) {
+                                throw new CoercingSerializeException(
+                                        "Unable to convert TemporalAccessor to seconds since epoch because of : '" + e.getMessage() + "'."
+                                );
+                            }
+                        }
+                    }
+                    throw new CoercingSerializeException(
+                            "Expected a 'Number', 'String' or 'TemporalAccessor' but was '" + typeName(input) + "'."
+                    );
+                } catch (CoercingSerializeException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new CoercingSerializeException(
+                            "Unable to convert to seconds since epoch because of : '" + e.getMessage() + "'."
+                    );
+                }
+            }
+
+            @Override
+            public TemporalAccessor parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
+                try {
+                    if (input instanceof Number) {
+                        Number number = (Number) input;
+                        return convertEpochSecondsToTemporal(number.longValue());
+                    }
+                    if (input instanceof String) {
+                        String string = (String) input;
+                        return convertToTemporal(string);
+                    }
+                    throw new CoercingParseValueException(
+                            "Expected a 'Number' or 'String' but was '" + typeName(input) + "'."
+                    );
+                } catch (CoercingParseValueException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new CoercingParseValueException(
+                            "Unable to parse value to seconds since epoch because of : '" + e.getMessage() + "'."
+                    );
+                }
+            }
+
+            @Override
+            public TemporalAccessor parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
+                try {
+                    if (input instanceof StringValue) {
+                        StringValue stringValue = (StringValue) input;
+                        return convertToTemporal(stringValue.getValue());
+                    }
+                    if (input instanceof IntValue) {
+                        IntValue intValue = (IntValue) input;
+                        long epochSeconds = intValue.getValue().longValue();
+                        return convertEpochSecondsToTemporal(epochSeconds);
+                    }
+                    throw new CoercingParseLiteralException(
+                            "Expected AST type 'StringValue' or 'IntValue' but was '" + typeName(input) + "'."
+                    );
+                } catch (CoercingParseLiteralException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new CoercingParseLiteralException(
+                            "Unable to parse literal to seconds since epoch because of : '" + e.getMessage() + "'."
+                    );
+                }
+            }
+
+            @Override
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+                Long value = serialize(input, graphQLContext, locale);
+                return IntValue.newIntValue(java.math.BigInteger.valueOf(value)).build();
+            }
+
+        };
+
+        INSTANCE = GraphQLScalarType.newScalar()
+                                    .name("SecondsSinceEpoch")
+                                    .description("Scalar that represents a point in time as seconds since the Unix epoch (Unix timestamp). " +
+                                            "Accepts integers or strings containing integers as input values. " +
+                                            "Returns a Long representing the number of seconds since epoch (January 1, 1970, 00:00:00 UTC).")
+                                    .coercing(coercing)
+                                    .build();
+    }
+}

--- a/src/main/java/graphql/scalars/datetime/TimeScalar.java
+++ b/src/main/java/graphql/scalars/datetime/TimeScalar.java
@@ -1,6 +1,8 @@
 package graphql.scalars.datetime;
 
+import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.execution.CoercedVariables;
 import graphql.language.StringValue;
 import graphql.language.Value;
 import graphql.schema.Coercing;
@@ -14,6 +16,7 @@ import java.time.OffsetTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
+import java.util.Locale;
 import java.util.function.Function;
 
 import static graphql.scalars.util.Kit.typeName;
@@ -28,12 +31,13 @@ public final class TimeScalar {
 
     public static final GraphQLScalarType INSTANCE;
 
-    private TimeScalar() {}
+    private TimeScalar() {
+    }
 
     static {
-        Coercing<OffsetTime, String> coercing = new Coercing<OffsetTime, String>() {
+        Coercing<OffsetTime, String> coercing = new Coercing<>() {
             @Override
-            public String serialize(Object input) throws CoercingSerializeException {
+            public String serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 TemporalAccessor temporalAccessor;
                 if (input instanceof TemporalAccessor) {
                     temporalAccessor = (TemporalAccessor) input;
@@ -54,7 +58,7 @@ public final class TimeScalar {
             }
 
             @Override
-            public OffsetTime parseValue(Object input) throws CoercingParseValueException {
+            public OffsetTime parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 TemporalAccessor temporalAccessor;
                 if (input instanceof TemporalAccessor) {
                     temporalAccessor = (TemporalAccessor) input;
@@ -75,7 +79,7 @@ public final class TimeScalar {
             }
 
             @Override
-            public OffsetTime parseLiteral(Object input) throws CoercingParseLiteralException {
+            public OffsetTime parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (!(input instanceof StringValue)) {
                     throw new CoercingParseLiteralException(
                             "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
@@ -85,8 +89,8 @@ public final class TimeScalar {
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
-                String s = serialize(input);
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+                String s = serialize(input, graphQLContext, locale);
                 return StringValue.newStringValue(s).build();
             }
 

--- a/src/main/java/graphql/scalars/datetime/YearMonthScalar.java
+++ b/src/main/java/graphql/scalars/datetime/YearMonthScalar.java
@@ -1,6 +1,8 @@
 package graphql.scalars.datetime;
 
+import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.execution.CoercedVariables;
 import graphql.language.StringValue;
 import graphql.language.Value;
 import graphql.schema.Coercing;
@@ -14,6 +16,7 @@ import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
+import java.util.Locale;
 import java.util.function.Function;
 
 import static graphql.scalars.util.Kit.typeName;
@@ -22,18 +25,19 @@ import static graphql.scalars.util.Kit.typeName;
  * Access this via {@link graphql.scalars.ExtendedScalars#YearMonth}
  */
 @Internal
-public final class YearMonthScalar  {
+public final class YearMonthScalar {
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM");
 
     public static final GraphQLScalarType INSTANCE;
 
-    private YearMonthScalar() {}
+    private YearMonthScalar() {
+    }
 
     static {
-        Coercing<YearMonth, String> coercing = new Coercing<YearMonth, String>() {
+        Coercing<YearMonth, String> coercing = new Coercing<>() {
             @Override
-            public String serialize(Object input) throws CoercingSerializeException {
+            public String serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 TemporalAccessor temporalAccessor;
                 if (input instanceof TemporalAccessor) {
                     temporalAccessor = (TemporalAccessor) input;
@@ -54,7 +58,7 @@ public final class YearMonthScalar  {
             }
 
             @Override
-            public YearMonth parseValue(Object input) throws CoercingParseValueException {
+            public YearMonth parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 TemporalAccessor temporalAccessor;
                 if (input instanceof TemporalAccessor) {
                     temporalAccessor = (TemporalAccessor) input;
@@ -75,7 +79,7 @@ public final class YearMonthScalar  {
             }
 
             @Override
-            public YearMonth parseLiteral(Object input) throws CoercingParseLiteralException {
+            public YearMonth parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (!(input instanceof StringValue)) {
                     throw new CoercingParseLiteralException(
                             "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
@@ -85,8 +89,8 @@ public final class YearMonthScalar  {
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
-                String s = serialize(input);
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+                String s = serialize(input, graphQLContext, locale);
                 return StringValue.newStringValue(s).build();
             }
 

--- a/src/main/java/graphql/scalars/datetime/YearScalar.java
+++ b/src/main/java/graphql/scalars/datetime/YearScalar.java
@@ -1,6 +1,8 @@
 package graphql.scalars.datetime;
 
+import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.execution.CoercedVariables;
 import graphql.language.StringValue;
 import graphql.language.Value;
 import graphql.schema.Coercing;
@@ -14,6 +16,7 @@ import java.time.Year;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
+import java.util.Locale;
 import java.util.function.Function;
 
 import static graphql.scalars.util.Kit.typeName;
@@ -22,18 +25,19 @@ import static graphql.scalars.util.Kit.typeName;
  * Access this via {@link graphql.scalars.ExtendedScalars#Year}
  */
 @Internal
-public final class YearScalar  {
+public final class YearScalar {
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy");
 
     public static final GraphQLScalarType INSTANCE;
 
-    private YearScalar() {}
+    private YearScalar() {
+    }
 
     static {
-        Coercing<Year, String> coercing = new Coercing<Year, String>() {
+        Coercing<Year, String> coercing = new Coercing<>() {
             @Override
-            public String serialize(Object input) throws CoercingSerializeException {
+            public String serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 TemporalAccessor temporalAccessor;
                 if (input instanceof TemporalAccessor) {
                     temporalAccessor = (TemporalAccessor) input;
@@ -54,7 +58,7 @@ public final class YearScalar  {
             }
 
             @Override
-            public Year parseValue(Object input) throws CoercingParseValueException {
+            public Year parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 TemporalAccessor temporalAccessor;
                 if (input instanceof TemporalAccessor) {
                     temporalAccessor = (TemporalAccessor) input;
@@ -75,7 +79,7 @@ public final class YearScalar  {
             }
 
             @Override
-            public Year parseLiteral(Object input) throws CoercingParseLiteralException {
+            public Year parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (!(input instanceof StringValue)) {
                     throw new CoercingParseLiteralException(
                             "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
@@ -85,8 +89,8 @@ public final class YearScalar  {
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
-                String s = serialize(input);
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+                String s = serialize(input, graphQLContext, locale);
                 return StringValue.newStringValue(s).build();
             }
 

--- a/src/main/java/graphql/scalars/id/UUIDScalar.java
+++ b/src/main/java/graphql/scalars/id/UUIDScalar.java
@@ -1,6 +1,8 @@
 package graphql.scalars.id;
 
+import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.execution.CoercedVariables;
 import graphql.language.StringValue;
 import graphql.language.Value;
 import graphql.scalars.util.Kit;
@@ -10,6 +12,7 @@ import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
 
+import java.util.Locale;
 import java.util.UUID;
 
 import static graphql.scalars.util.Kit.typeName;
@@ -23,7 +26,7 @@ public class UUIDScalar {
     public static GraphQLScalarType INSTANCE;
 
     static {
-        Coercing<UUID, String> coercing = new Coercing<UUID, String>() {
+        Coercing<UUID, String> coercing = new Coercing<>() {
             private UUID convertImpl(Object input) {
                 if (input instanceof String) {
                     try {
@@ -38,7 +41,7 @@ public class UUIDScalar {
             }
 
             @Override
-            public String serialize(Object input) throws CoercingSerializeException {
+            public String serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 UUID result = convertImpl(input);
                 if (result == null) {
                     throw new CoercingSerializeException(
@@ -49,7 +52,7 @@ public class UUIDScalar {
             }
 
             @Override
-            public UUID parseValue(Object input) throws CoercingParseValueException {
+            public UUID parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 UUID result = convertImpl(input);
                 if (result == null) {
                     throw new CoercingParseValueException(
@@ -60,7 +63,7 @@ public class UUIDScalar {
             }
 
             @Override
-            public UUID parseLiteral(Object input) throws CoercingParseLiteralException {
+            public UUID parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (!(input instanceof StringValue)) {
                     throw new CoercingParseLiteralException(
                             "Expected a 'java.util.UUID' AST type object but was '" + typeName(input) + "'."
@@ -76,8 +79,8 @@ public class UUIDScalar {
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
-                String s = serialize(input);
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+                String s = serialize(input, graphQLContext, locale);
                 return StringValue.newStringValue(s).build();
             }
         };

--- a/src/main/java/graphql/scalars/java/JavaPrimitives.java
+++ b/src/main/java/graphql/scalars/java/JavaPrimitives.java
@@ -1,6 +1,8 @@
 package graphql.scalars.java;
 
+import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.execution.CoercedVariables;
 import graphql.language.FloatValue;
 import graphql.language.IntValue;
 import graphql.language.StringValue;
@@ -13,6 +15,7 @@ import graphql.schema.GraphQLScalarType;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -21,7 +24,8 @@ import java.util.Objects;
 @Internal
 public final class JavaPrimitives {
 
-    private JavaPrimitives() {}
+    private JavaPrimitives() {
+    }
 
     private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
     private static final BigInteger LONG_MIN = BigInteger.valueOf(Long.MIN_VALUE);
@@ -48,7 +52,7 @@ public final class JavaPrimitives {
     public static final GraphQLScalarType GraphQLLong;
 
     static {
-        Coercing<Long, Long> longCoercing = new Coercing<Long, Long>() {
+        Coercing<Long, Long> longCoercing = new Coercing<>() {
 
             private Long convertImpl(Object input) {
                 if (input instanceof Long) {
@@ -72,7 +76,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Long serialize(Object input) {
+            public Long serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 Long result = convertImpl(input);
                 if (result == null) {
                     throw new CoercingSerializeException(
@@ -83,7 +87,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Long parseValue(Object input) {
+            public Long parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 Long result = convertImpl(input);
                 if (result == null) {
                     throw new CoercingParseValueException(
@@ -94,7 +98,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Long parseLiteral(Object input) {
+            public Long parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (input instanceof StringValue) {
                     try {
                         return Long.parseLong(((StringValue) input).getValue());
@@ -118,7 +122,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
                 Long result = Objects.requireNonNull(convertImpl(input));
                 return IntValue.newIntValue(BigInteger.valueOf(result)).build();
             }
@@ -135,7 +139,7 @@ public final class JavaPrimitives {
     public static final GraphQLScalarType GraphQLShort;
 
     static {
-        Coercing<Short, Short> shortCoercing = new Coercing<Short, Short>() {
+        Coercing<Short, Short> shortCoercing = new Coercing<>() {
 
             private Short convertImpl(Object input) {
                 if (input instanceof Short) {
@@ -159,7 +163,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Short serialize(Object input) {
+            public Short serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 Short result = convertImpl(input);
                 if (result == null) {
                     throw new CoercingSerializeException(
@@ -170,7 +174,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Short parseValue(Object input) {
+            public Short parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 Short result = convertImpl(input);
                 if (result == null) {
                     throw new CoercingParseValueException(
@@ -181,7 +185,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Short parseLiteral(Object input) {
+            public Short parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (!(input instanceof IntValue)) {
                     throw new CoercingParseLiteralException(
                             "Expected AST type 'IntValue' but was '" + typeName(input) + "'."
@@ -197,7 +201,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
                 Short result = Objects.requireNonNull(convertImpl(input));
                 return IntValue.newIntValue(BigInteger.valueOf(result)).build();
             }
@@ -214,7 +218,7 @@ public final class JavaPrimitives {
     public static final GraphQLScalarType GraphQLByte;
 
     static {
-        Coercing<Byte, Byte> byteCoercing = new Coercing<Byte, Byte>() {
+        Coercing<Byte, Byte> byteCoercing = new Coercing<>() {
 
             private Byte convertImpl(Object input) {
                 if (input instanceof Byte) {
@@ -238,7 +242,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Byte serialize(Object input) {
+            public Byte serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 Byte result = convertImpl(input);
                 if (result == null) {
                     throw new CoercingSerializeException(
@@ -249,7 +253,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Byte parseValue(Object input) {
+            public Byte parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 Byte result = convertImpl(input);
                 if (result == null) {
                     throw new CoercingParseValueException(
@@ -260,7 +264,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Byte parseLiteral(Object input) {
+            public Byte parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (!(input instanceof IntValue)) {
                     throw new CoercingParseLiteralException(
                             "Expected AST type 'IntValue' but was '" + typeName(input) + "'."
@@ -276,7 +280,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
                 Byte result = Objects.requireNonNull(convertImpl(input));
                 return IntValue.newIntValue(BigInteger.valueOf(result)).build();
             }
@@ -294,7 +298,7 @@ public final class JavaPrimitives {
     public static final GraphQLScalarType GraphQLBigInteger;
 
     static {
-        Coercing<BigInteger, BigInteger> bigIntCoercing = new Coercing<BigInteger, BigInteger>() {
+        Coercing<BigInteger, BigInteger> bigIntCoercing = new Coercing<>() {
 
             private BigInteger convertImpl(Object input) {
                 if (isNumberIsh(input)) {
@@ -315,7 +319,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public BigInteger serialize(Object input) {
+            public BigInteger serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 BigInteger result = convertImpl(input);
                 if (result == null) {
                     throw new CoercingSerializeException(
@@ -326,7 +330,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public BigInteger parseValue(Object input) {
+            public BigInteger parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 BigInteger result = convertImpl(input);
                 if (result == null) {
                     throw new CoercingParseValueException(
@@ -337,7 +341,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public BigInteger parseLiteral(Object input) {
+            public BigInteger parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (input instanceof StringValue) {
                     try {
                         return new BigDecimal(((StringValue) input).getValue()).toBigIntegerExact();
@@ -363,7 +367,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
                 BigInteger result = Objects.requireNonNull(convertImpl(input));
                 return IntValue.newIntValue(result).build();
             }
@@ -380,7 +384,7 @@ public final class JavaPrimitives {
     public static final GraphQLScalarType GraphQLBigDecimal;
 
     static {
-        Coercing<BigDecimal, BigDecimal> bigDecimalCoercing = new Coercing<BigDecimal, BigDecimal>() {
+        Coercing<BigDecimal, BigDecimal> bigDecimalCoercing = new Coercing<>() {
 
             private BigDecimal convertImpl(Object input) {
                 if (isNumberIsh(input)) {
@@ -395,7 +399,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public BigDecimal serialize(Object input) {
+            public BigDecimal serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 BigDecimal result = convertImpl(input);
                 if (result == null) {
                     throw new CoercingSerializeException(
@@ -406,7 +410,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public BigDecimal parseValue(Object input) {
+            public BigDecimal parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 BigDecimal result = convertImpl(input);
                 if (result == null) {
                     throw new CoercingParseValueException(
@@ -417,7 +421,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public BigDecimal parseLiteral(Object input) {
+            public BigDecimal parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (input instanceof StringValue) {
                     try {
                         return new BigDecimal(((StringValue) input).getValue());
@@ -437,7 +441,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
                 BigDecimal result = Objects.requireNonNull(convertImpl(input));
                 return FloatValue.newFloatValue(result).build();
             }
@@ -456,7 +460,7 @@ public final class JavaPrimitives {
     public static final GraphQLScalarType GraphQLChar;
 
     static {
-        Coercing<Character, Character> characterCoercing = new Coercing<Character, Character>() {
+        Coercing<Character, Character> characterCoercing = new Coercing<>() {
 
             private Character convertImpl(Object input) {
                 if (input instanceof String && ((String) input).length() == 1) {
@@ -470,7 +474,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Character serialize(Object input) {
+            public Character serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 Character result = convertImpl(input);
                 if (result == null) {
                     throw new CoercingSerializeException(
@@ -481,7 +485,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Character parseValue(Object input) {
+            public Character parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 Character result = convertImpl(input);
                 if (result == null) {
                     throw new CoercingParseValueException(
@@ -492,7 +496,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Character parseLiteral(Object input) {
+            public Character parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (!(input instanceof StringValue)) {
                     throw new CoercingParseLiteralException(
                             "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
@@ -508,7 +512,7 @@ public final class JavaPrimitives {
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
                 Character result = Objects.requireNonNull(convertImpl(input));
                 return StringValue.newStringValue(result.toString()).build();
             }

--- a/src/main/java/graphql/scalars/locale/LocaleScalar.java
+++ b/src/main/java/graphql/scalars/locale/LocaleScalar.java
@@ -1,6 +1,8 @@
 package graphql.scalars.locale;
 
+import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.execution.CoercedVariables;
 import graphql.language.StringValue;
 import graphql.language.Value;
 import graphql.schema.Coercing;
@@ -19,15 +21,16 @@ import static graphql.scalars.util.Kit.typeName;
 @Internal
 public final class LocaleScalar {
 
-    private LocaleScalar() {}
+    private LocaleScalar() {
+    }
 
     public static final GraphQLScalarType INSTANCE;
 
     static {
-        Coercing<Locale, String> coercing = new Coercing<Locale, String>() {
+        Coercing<Locale, String> coercing = new Coercing<>() {
 
             @Override
-            public String serialize(Object input) throws CoercingSerializeException {
+            public String serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 if (input instanceof String) {
                     try {
                         return Locale.forLanguageTag((String) input).toLanguageTag();
@@ -45,7 +48,7 @@ public final class LocaleScalar {
             }
 
             @Override
-            public Locale parseValue(Object input) throws CoercingParseValueException {
+            public Locale parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 if (input instanceof String) {
                     try {
                         return Locale.forLanguageTag(input.toString());
@@ -61,8 +64,9 @@ public final class LocaleScalar {
                 }
             }
 
+
             @Override
-            public Locale parseLiteral(Object input) throws CoercingParseLiteralException {
+            public Locale parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (input instanceof StringValue) {
                     return Locale.forLanguageTag(((StringValue) input).getValue());
                 } else {
@@ -72,8 +76,8 @@ public final class LocaleScalar {
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
-                String s = serialize(input);
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+                String s = serialize(input, graphQLContext, locale);
                 return StringValue.newStringValue(s).build();
             }
         };

--- a/src/main/java/graphql/scalars/numeric/FloatCoercing.java
+++ b/src/main/java/graphql/scalars/numeric/FloatCoercing.java
@@ -1,12 +1,15 @@
 package graphql.scalars.numeric;
 
+import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.execution.CoercedVariables;
 import graphql.language.Value;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 
+import java.util.Locale;
 import java.util.function.Function;
 
 import static graphql.Scalars.GraphQLFloat;
@@ -17,25 +20,26 @@ abstract class FloatCoercing implements Coercing<Double, Double> {
     protected abstract Double check(Double d, Function<String, RuntimeException> exceptionMaker);
 
     @Override
-    public Double serialize(Object input) throws CoercingSerializeException {
-        Double d = (Double) GraphQLFloat.getCoercing().serialize(input);
+    public Double serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
+        Double d = (Double) GraphQLFloat.getCoercing().serialize(input, graphQLContext, locale);
         return check(d, CoercingSerializeException::new);
     }
 
     @Override
-    public Double parseValue(Object input) throws CoercingParseValueException {
-        Double d = (Double) GraphQLFloat.getCoercing().parseValue(input);
+    public Double parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
+        Double d = (Double) GraphQLFloat.getCoercing().parseValue(input, graphQLContext, locale);
         return check(d, CoercingParseValueException::new);
     }
 
     @Override
-    public Double parseLiteral(Object input) throws CoercingParseLiteralException {
-        Double d = (Double) GraphQLFloat.getCoercing().parseLiteral(input);
+    public Double parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
+        Double d = (Double) GraphQLFloat.getCoercing().parseLiteral(input, variables, graphQLContext, locale);
         return check(d, CoercingParseLiteralException::new);
     }
 
     @Override
-    public Value<?> valueToLiteral(Object input) {
-        return GraphQLFloat.getCoercing().valueToLiteral(input);
+    public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+        return GraphQLFloat.getCoercing().valueToLiteral(input, graphQLContext, locale);
     }
+
 }

--- a/src/main/java/graphql/scalars/numeric/IntCoercing.java
+++ b/src/main/java/graphql/scalars/numeric/IntCoercing.java
@@ -1,12 +1,15 @@
 package graphql.scalars.numeric;
 
+import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.execution.CoercedVariables;
 import graphql.language.Value;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 
+import java.util.Locale;
 import java.util.function.Function;
 
 import static graphql.Scalars.GraphQLInt;
@@ -17,26 +20,25 @@ abstract class IntCoercing implements Coercing<Integer, Integer> {
     protected abstract Integer check(Integer i, Function<String, RuntimeException> exceptionMaker);
 
     @Override
-    public Integer serialize(Object input) throws CoercingSerializeException {
-        Integer i = (Integer) GraphQLInt.getCoercing().serialize(input);
+    public Integer serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
+        Integer i = (Integer) GraphQLInt.getCoercing().serialize(input, graphQLContext, locale);
         return check(i, CoercingSerializeException::new);
     }
 
     @Override
-    public Integer parseValue(Object input) throws CoercingParseValueException {
-        Integer i = (Integer) GraphQLInt.getCoercing().parseValue(input);
+    public Integer parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
+        Integer i = (Integer) GraphQLInt.getCoercing().parseValue(input, graphQLContext, locale);
         return check(i, CoercingParseValueException::new);
     }
 
     @Override
-    public Integer parseLiteral(Object input) throws CoercingParseLiteralException {
-        Integer i = (Integer) GraphQLInt.getCoercing().parseLiteral(input);
+    public Integer parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
+        Integer i = (Integer) GraphQLInt.getCoercing().parseLiteral(input, variables, graphQLContext, locale);
         return check(i, CoercingParseLiteralException::new);
     }
 
     @Override
-    public Value<?> valueToLiteral(Object input) {
-        return GraphQLInt.getCoercing().valueToLiteral(input);
+    public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+        return GraphQLInt.getCoercing().valueToLiteral(input, graphQLContext, locale);
     }
-
 }

--- a/src/main/java/graphql/scalars/regex/RegexScalar.java
+++ b/src/main/java/graphql/scalars/regex/RegexScalar.java
@@ -1,7 +1,9 @@
 package graphql.scalars.regex;
 
 import graphql.Assert;
+import graphql.GraphQLContext;
 import graphql.PublicApi;
+import graphql.execution.CoercedVariables;
 import graphql.language.StringValue;
 import graphql.language.Value;
 import graphql.schema.Coercing;
@@ -13,6 +15,7 @@ import graphql.schema.GraphQLScalarType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -26,7 +29,8 @@ import static graphql.scalars.util.Kit.typeName;
 @PublicApi
 public final class RegexScalar {
 
-    private RegexScalar() {}
+    private RegexScalar() {
+    }
 
     /**
      * A builder for {@link graphql.scalars.regex.RegexScalar}
@@ -34,7 +38,7 @@ public final class RegexScalar {
     public static class Builder {
         private String name;
         private String description;
-        private List<Pattern> patterns = new ArrayList<>();
+        private final List<Pattern> patterns = new ArrayList<>();
 
         /**
          * Sets the name of the regex scalar
@@ -96,21 +100,21 @@ public final class RegexScalar {
     private static GraphQLScalarType regexScalarImpl(String name, String description, List<Pattern> patterns) {
         Assert.assertNotNull(patterns);
 
-        Coercing<String, String> coercing = new Coercing<String, String>() {
+        Coercing<String, String> coercing = new Coercing<>() {
             @Override
-            public String serialize(Object input) throws CoercingSerializeException {
+            public String serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 String value = String.valueOf(input);
                 return matches(value, CoercingSerializeException::new);
             }
 
             @Override
-            public String parseValue(Object input) throws CoercingParseValueException {
+            public String parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 String value = String.valueOf(input);
                 return matches(value, CoercingParseValueException::new);
             }
 
             @Override
-            public String parseLiteral(Object input) throws CoercingParseLiteralException {
+            public String parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (!(input instanceof StringValue)) {
                     throw new CoercingParseLiteralException(
                             "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
@@ -121,8 +125,8 @@ public final class RegexScalar {
             }
 
             @Override
-            public Value<?> valueToLiteral(Object input) {
-                String s = serialize(input);
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+                String s = serialize(input, graphQLContext, locale);
                 return StringValue.newStringValue(s).build();
             }
 

--- a/src/main/java/graphql/scalars/url/UrlScalar.java
+++ b/src/main/java/graphql/scalars/url/UrlScalar.java
@@ -1,6 +1,8 @@
 package graphql.scalars.url;
 
+import graphql.GraphQLContext;
 import graphql.Internal;
+import graphql.execution.CoercedVariables;
 import graphql.language.StringValue;
 import graphql.language.Value;
 import graphql.schema.Coercing;
@@ -13,6 +15,7 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -21,14 +24,15 @@ import static graphql.scalars.util.Kit.typeName;
 @Internal
 public final class UrlScalar {
 
-    private UrlScalar() {}
+    private UrlScalar() {
+    }
 
     public static final GraphQLScalarType INSTANCE;
 
     static {
-        Coercing<URL, URL> coercing = new Coercing<URL, URL>() {
+        Coercing<URL, URL> coercing = new Coercing<>() {
             @Override
-            public URL serialize(Object input) throws CoercingSerializeException {
+            public URL serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
                 Optional<URL> url;
                 if (input instanceof String) {
                     url = Optional.of(parseURL(input.toString(), CoercingSerializeException::new));
@@ -44,13 +48,13 @@ public final class UrlScalar {
             }
 
             @Override
-            public URL parseValue(Object input) throws CoercingParseValueException {
+            public URL parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
                 String urlStr;
                 if (input instanceof String) {
                     urlStr = String.valueOf(input);
                 } else {
                     Optional<URL> url = toURL(input);
-                    if (!url.isPresent()) {
+                    if (url.isEmpty()) {
                         throw new CoercingParseValueException(
                                 "Expected a 'URL' like object but was '" + typeName(input) + "'."
                         );
@@ -61,7 +65,7 @@ public final class UrlScalar {
             }
 
             @Override
-            public URL parseLiteral(Object input) throws CoercingParseLiteralException {
+            public URL parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
                 if (!(input instanceof StringValue)) {
                     throw new CoercingParseLiteralException(
                             "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
@@ -71,8 +75,8 @@ public final class UrlScalar {
             }
 
             @Override
-            public Value valueToLiteral(Object input) {
-                URL url = serialize(input);
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+                URL url = serialize(input, graphQLContext, locale);
                 return StringValue.newStringValue(url.toExternalForm()).build();
             }
 

--- a/src/test/groovy/graphql/scalars/alias/AliasedScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/alias/AliasedScalarTest.groovy
@@ -3,10 +3,10 @@ package graphql.scalars.alias
 import graphql.Scalars
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.GraphQLScalarType
-import spock.lang.Specification
 
-class AliasedScalarTest extends Specification {
+class AliasedScalarTest extends AbstractScalarTest {
 
     GraphQLScalarType socialMediaLink = ExtendedScalars.newAliasedScalar("SocialMediaLink")
             .aliasedScalar(Scalars.GraphQLString)
@@ -15,22 +15,17 @@ class AliasedScalarTest extends Specification {
     def "basic wrapping"() {
 
         when:
-        def result = socialMediaLink.coercing.serialize("ABC")
+        def result = socialMediaLink.coercing.serialize("ABC", graphQLContext, locale)
         then:
         result == "ABC"
 
         when:
-        result = socialMediaLink.coercing.parseValue("ABC")
+        result = socialMediaLink.coercing.parseValue("ABC", graphQLContext, locale)
         then:
         result == "ABC"
 
         when:
-        result = socialMediaLink.coercing.parseLiteral(new StringValue("ABC"))
-        then:
-        result == "ABC"
-
-        when:
-        result = socialMediaLink.coercing.parseLiteral(new StringValue("ABC"), [:])
+        result = socialMediaLink.coercing.parseLiteral(new StringValue("ABC"), variables, graphQLContext, locale)
         then:
         result == "ABC"
 

--- a/src/test/groovy/graphql/scalars/color/hex/HexColorCodeScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/color/hex/HexColorCodeScalarTest.groovy
@@ -2,20 +2,20 @@ package graphql.scalars.color.hex
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseValueException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.mkColor
 
-class HexColorCodeScalarTest extends Specification {
+class HexColorCodeScalarTest extends AbstractScalarTest {
 
     def coercing = ExtendedScalars.HexColorCode.getCoercing()
 
     @Unroll
     def "invoke parseValue for hexCode"() {
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         result.equals(expectedValue)
         where:
@@ -29,7 +29,7 @@ class HexColorCodeScalarTest extends Specification {
     @Unroll
     def "invoke parseLiteral for hexCode"() {
         when:
-        def result = coercing.parseLiteral(input)
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -43,7 +43,7 @@ class HexColorCodeScalarTest extends Specification {
     @Unroll
     def "invoke serialize with hexCode"() {
         when:
-        def result = coercing.serialize(input)
+        def result = coercing.serialize(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -59,7 +59,7 @@ class HexColorCodeScalarTest extends Specification {
     @Unroll
     def "invoke valueToLiteral with hexCode"() {
         when:
-        def result = coercing.valueToLiteral(input)
+        def result = coercing.valueToLiteral(input, graphQLContext, locale)
         then:
         result.isEqualTo(expectedValue)
         where:
@@ -75,7 +75,7 @@ class HexColorCodeScalarTest extends Specification {
     @Unroll
     def "parseValue throws exception for invalid input #input"() {
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         thrown(CoercingParseValueException)
         where:

--- a/src/test/groovy/graphql/scalars/country/code/CountryCodeScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/country/code/CountryCodeScalarTest.groovy
@@ -2,21 +2,22 @@ package graphql.scalars.country.code
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseValueException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.mkCountryCode
 import static graphql.scalars.util.TestKit.mkStringValue
 
-class CountryCodeScalarTest extends Specification {
+class CountryCodeScalarTest extends AbstractScalarTest {
 
     def coercing = ExtendedScalars.CountryCode.getCoercing()
+
 
     @Unroll
     def "invoke parseValue for countryCode"() {
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -31,7 +32,7 @@ class CountryCodeScalarTest extends Specification {
     def "invoke parseLiteral for countryCode"() {
 
         when:
-        def result = coercing.parseLiteral(input)
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -44,7 +45,7 @@ class CountryCodeScalarTest extends Specification {
     @Unroll
     def "invoke serialize with countryCode"() {
         when:
-        def result = coercing.serialize(input)
+        def result = coercing.serialize(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -59,7 +60,7 @@ class CountryCodeScalarTest extends Specification {
     def "invoke valueToLiteral with countryCode"() {
 
         when:
-        def result = coercing.valueToLiteral(input)
+        def result = coercing.valueToLiteral(input, graphQLContext, locale)
         then:
         result.isEqualTo(expectedValue)
         where:
@@ -73,7 +74,7 @@ class CountryCodeScalarTest extends Specification {
     @Unroll
     def "parseValue throws exception for invalid input #value"() {
         when:
-        coercing.parseValue(value)
+        coercing.parseValue(value, graphQLContext, locale)
         then:
         thrown(CoercingParseValueException)
 
@@ -83,8 +84,8 @@ class CountryCodeScalarTest extends Specification {
         "US(UNITED STATES)"  | _
         "not a countryCode " | _
         "42.3"               | _
-        new Double(42.3)     | _
-        new Float(42.3)      | _
+        Double.valueOf(42.3) | _
+        Float.valueOf(42.3)  | _
         new Object()         | _
     }
 
@@ -92,7 +93,7 @@ class CountryCodeScalarTest extends Specification {
     @Unroll
     def "invoke parseValue with all countryCode list"() {
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:

--- a/src/test/groovy/graphql/scalars/currency/CurrencyScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/currency/CurrencyScalarTest.groovy
@@ -2,14 +2,14 @@ package graphql.scalars.currency
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseValueException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.mkCurrency
 import static graphql.scalars.util.TestKit.mkStringValue
 
-class CurrencyScalarTest extends Specification {
+class CurrencyScalarTest extends AbstractScalarTest {
 
 
     def coercing = ExtendedScalars.Currency.getCoercing()
@@ -18,7 +18,7 @@ class CurrencyScalarTest extends Specification {
     def "currency parseValue cases"() {
 
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -42,7 +42,7 @@ class CurrencyScalarTest extends Specification {
     def "currency parseLiteral"() {
 
         when:
-        def result = coercing.parseLiteral(input)
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -56,7 +56,7 @@ class CurrencyScalarTest extends Specification {
     def "currency serialize"() {
 
         when:
-        def result = coercing.serialize(input)
+        def result = coercing.serialize(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -69,7 +69,7 @@ class CurrencyScalarTest extends Specification {
     def "currency valueToLiteral"() {
 
         when:
-        def result = coercing.valueToLiteral(input)
+        def result = coercing.valueToLiteral(input, graphQLContext, locale)
         then:
         result.isEqualTo(expectedValue)
         where:
@@ -81,19 +81,19 @@ class CurrencyScalarTest extends Specification {
     @Unroll
     def "parseValue throws exception for invalid input #value"() {
         when:
-        coercing.parseValue(value)
+        coercing.parseValue(value, graphQLContext, locale)
         then:
         thrown(CoercingParseValueException)
 
         where:
-        value             | _
-        ""                | _
-        "US_DOLLAR"       | _
-        "not a currency " | _
-        "42.3"            | _
-        new Double(42.3)  | _
-        new Float(42.3)   | _
-        new Object()      | _
+        value                | _
+        ""                   | _
+        "US_DOLLAR"          | _
+        "not a currency "    | _
+        "42.3"               | _
+        Double.valueOf(42.3) | _
+        Float.valueOf(42.3)  | _
+        new Object()         | _
     }
 
 
@@ -101,7 +101,7 @@ class CurrencyScalarTest extends Specification {
     def "all currency ISO list parseValue"() {
 
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:

--- a/src/test/groovy/graphql/scalars/datetime/AccurateDurationScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/AccurateDurationScalarTest.groovy
@@ -1,21 +1,21 @@
 package graphql.scalars.datetime
 
-
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.time.Period
 import java.time.temporal.ChronoUnit
 
 import static graphql.scalars.util.TestKit.mkDuration
+import static graphql.scalars.util.TestKit.mkIntValue
 import static graphql.scalars.util.TestKit.mkStringValue
 
-class AccurateDurationScalarTest extends Specification {
+class AccurateDurationScalarTest extends AbstractScalarTest {
 
     def coercing = ExtendedScalars.AccurateDuration.getCoercing()
 
@@ -23,7 +23,7 @@ class AccurateDurationScalarTest extends Specification {
     def "accurateduration parseValue"() {
 
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -40,7 +40,7 @@ class AccurateDurationScalarTest extends Specification {
     def "accurateduration valueToLiteral"() {
 
         when:
-        def result = coercing.valueToLiteral(input)
+        def result = coercing.valueToLiteral(input, graphQLContext, locale)
         then:
         result.isEqualTo(expectedValue)
         where:
@@ -58,7 +58,7 @@ class AccurateDurationScalarTest extends Specification {
     def "accurateduration parseValue bad inputs"() {
 
         when:
-        coercing.parseValue(input)
+        coercing.parseValue(input, graphQLContext, locale)
         then:
         thrown(expectedValue)
         where:
@@ -75,7 +75,7 @@ class AccurateDurationScalarTest extends Specification {
     def "accurateduration AST literal"() {
 
         when:
-        def result = coercing.parseLiteral(input)
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -86,7 +86,7 @@ class AccurateDurationScalarTest extends Specification {
     def "accurateduration serialisation"() {
 
         when:
-        def result = coercing.serialize(input)
+        def result = coercing.serialize(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -103,7 +103,7 @@ class AccurateDurationScalarTest extends Specification {
     def "accurateduration serialisation bad inputs"() {
 
         when:
-        coercing.serialize(input)
+        coercing.serialize(input, graphQLContext, locale)
         then:
         thrown(expectedValue)
         where:
@@ -122,18 +122,17 @@ class AccurateDurationScalarTest extends Specification {
     def "accurateduration parseLiteral bad inputs"() {
 
         when:
-        coercing.parseLiteral(input)
+        coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         thrown(expectedValue)
         where:
-        input              | expectedValue
-        "P1M"              | CoercingParseLiteralException
-        "PT1.5M"           | CoercingParseLiteralException
-        "P1MT2H"           | CoercingParseLiteralException
-        "P2W"              | CoercingParseLiteralException
-        "P3Y"              | CoercingParseLiteralException
-        123                | CoercingParseLiteralException
-        ""                 | CoercingParseLiteralException
-        Period.of(1, 2, 3) | CoercingParseLiteralException
+        input                   | expectedValue
+        mkStringValue("P1M")    | CoercingParseLiteralException
+        mkStringValue("PT1.5M") | CoercingParseLiteralException
+        mkStringValue("P1MT2H") | CoercingParseLiteralException
+        mkStringValue("P2W")    | CoercingParseLiteralException
+        mkStringValue("P3Y")    | CoercingParseLiteralException
+        mkIntValue(123)         | CoercingParseLiteralException
+        mkStringValue("")       | CoercingParseLiteralException
     }
 }

--- a/src/test/groovy/graphql/scalars/datetime/DateScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/DateScalarTest.groovy
@@ -2,7 +2,7 @@ package graphql.scalars.datetime
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
-import spock.lang.Specification
+import graphql.scalars.util.AbstractScalarTest
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.mkLocalDate
@@ -10,7 +10,7 @@ import static graphql.scalars.util.TestKit.mkOffsetDT
 import static graphql.scalars.util.TestKit.mkStringValue
 import static graphql.scalars.util.TestKit.mkZonedDT
 
-class DateScalarTest extends Specification {
+class DateScalarTest extends AbstractScalarTest {
 
     def coercing = ExtendedScalars.Date.getCoercing()
 
@@ -18,7 +18,7 @@ class DateScalarTest extends Specification {
     def "full date parseValue"() {
 
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -32,7 +32,7 @@ class DateScalarTest extends Specification {
     def "full date parseLiteral"() {
 
         when:
-        def result = coercing.parseLiteral(input)
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -44,7 +44,7 @@ class DateScalarTest extends Specification {
     def "full date serialize"() {
 
         when:
-        def result = coercing.serialize(input)
+        def result = coercing.serialize(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -58,7 +58,7 @@ class DateScalarTest extends Specification {
     def "full date valueToLiteral"() {
 
         when:
-        def result = coercing.valueToLiteral(input)
+        def result = coercing.valueToLiteral(input, graphQLContext, locale)
         then:
         result.isEqualTo(expectedValue)
         where:

--- a/src/test/groovy/graphql/scalars/datetime/DateTimeScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/DateTimeScalarTest.groovy
@@ -2,18 +2,19 @@ package graphql.scalars.datetime
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
+import static graphql.scalars.util.TestKit.mkIntValue
 import static graphql.scalars.util.TestKit.mkLocalDT
 import static graphql.scalars.util.TestKit.mkOffsetDT
 import static graphql.scalars.util.TestKit.mkStringValue
 import static graphql.scalars.util.TestKit.mkZonedDT
 
-class DateTimeScalarTest extends Specification {
+class DateTimeScalarTest extends AbstractScalarTest {
 
     def coercing = ExtendedScalars.DateTime.getCoercing()
 
@@ -21,7 +22,7 @@ class DateTimeScalarTest extends Specification {
     def "datetime parseValue"() {
 
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -38,7 +39,7 @@ class DateTimeScalarTest extends Specification {
     def "datetime valueToLiteral"() {
 
         when:
-        def result = coercing.valueToLiteral(input)
+        def result = coercing.valueToLiteral(input, graphQLContext, locale)
         then:
         result.isEqualTo(expectedValue)
         where:
@@ -56,25 +57,25 @@ class DateTimeScalarTest extends Specification {
     def "datetime parseValue bad inputs"() {
 
         when:
-        coercing.parseValue(input)
+        coercing.parseValue(input, graphQLContext, locale)
         then:
         thrown(expectedValue)
         where:
-        input                              | expectedValue
-        "1985-04-12"                       | CoercingParseValueException // No time provided
-        "2022-11-24T01:00:01.02-00:00"     | CoercingParseValueException // -00:00 is not a valid offset in specification
-        mkLocalDT(year: 1980, hour: 3)     | CoercingParseValueException // LocalDateTime has no time zone
-        666                                | CoercingParseValueException // A random number
-        "2011-08-30T13:22:53.108"          | CoercingParseValueException // No offset provided
-        "2011-08-30T24:22:53.108Z"         | CoercingParseValueException // 24 is not allowed as hour of the time
-        "2010-02-30T21:22:53.108Z"         | CoercingParseValueException // 30th of February is not a valid date
-        "2010-02-11T21:22:53.108Z+25:11"   | CoercingParseValueException // 25 is not a valid hour for offset
+        input                            | expectedValue
+        "1985-04-12"                     | CoercingParseValueException // No time provided
+        "2022-11-24T01:00:01.02-00:00"   | CoercingParseValueException // -00:00 is not a valid offset in specification
+        mkLocalDT(year: 1980, hour: 3)   | CoercingParseValueException // LocalDateTime has no time zone
+        666                              | CoercingParseValueException // A random number
+        "2011-08-30T13:22:53.108"        | CoercingParseValueException // No offset provided
+        "2011-08-30T24:22:53.108Z"       | CoercingParseValueException // 24 is not allowed as hour of the time
+        "2010-02-30T21:22:53.108Z"       | CoercingParseValueException // 30th of February is not a valid date
+        "2010-02-11T21:22:53.108Z+25:11" | CoercingParseValueException // 25 is not a valid hour for offset
     }
 
     def "datetime AST literal"() {
 
         when:
-        def result = coercing.parseLiteral(input)
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -85,7 +86,7 @@ class DateTimeScalarTest extends Specification {
     def "datetime serialisation"() {
 
         when:
-        def result = coercing.serialize(input)
+        def result = coercing.serialize(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -101,7 +102,7 @@ class DateTimeScalarTest extends Specification {
     def "datetime serialisation bad inputs"() {
 
         when:
-        coercing.serialize(input)
+        coercing.serialize(input, graphQLContext, locale)
         then:
         thrown(expectedValue)
         where:
@@ -120,20 +121,19 @@ class DateTimeScalarTest extends Specification {
     def "datetime parseLiteral bad inputs"() {
 
         when:
-        coercing.parseLiteral(input)
+        coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         thrown(expectedValue)
         where:
-        input                            | expectedValue
-        "2022-11-24T01:00:01.02-00:00"   | CoercingParseLiteralException // -00:00 is not a valid offset in specification
-        "1985-04-12"                     | CoercingParseLiteralException // No time provided
-        "2022-11-24T01:00:01.02-00:00"   | CoercingParseLiteralException // -00:00 is not a valid offset in specification
-        mkLocalDT(year: 1980, hour: 3)   | CoercingParseLiteralException // LocalDateTime has no time zone
-        666                              | CoercingParseLiteralException // A random number
-        "2011-08-30T13:22:53.108"        | CoercingParseLiteralException // No offset provided
-        "2011-08-30T24:22:53.108Z"       | CoercingParseLiteralException // 24 is not allowed as hour of the time
-        "2010-02-30T21:22:53.108Z"       | CoercingParseLiteralException // 30th of February is not a valid date
-        "2010-02-11T21:22:53.108Z+25:11" | CoercingParseLiteralException // 25 is not a valid hour for offset
+        input                                           | expectedValue
+        mkStringValue("2022-11-24T01:00:01.02-00:00")   | CoercingParseLiteralException // -00:00 is not a valid offset in specification
+        mkStringValue("1985-04-12")                     | CoercingParseLiteralException // No time provided
+        mkStringValue("2022-11-24T01:00:01.02-00:00")   | CoercingParseLiteralException // -00:00 is not a valid offset in specification
+        mkIntValue(666)                                 | CoercingParseLiteralException // A random number
+        mkStringValue("2011-08-30T13:22:53.108")        | CoercingParseLiteralException // No offset provided
+        mkStringValue("2011-08-30T24:22:53.108Z")       | CoercingParseLiteralException // 24 is not allowed as hour of the time
+        mkStringValue("2010-02-30T21:22:53.108Z")       | CoercingParseLiteralException // 30th of February is not a valid date
+        mkStringValue("2010-02-11T21:22:53.108Z+25:11") | CoercingParseLiteralException // 25 is not a valid hour for offset
     }
 
 }

--- a/src/test/groovy/graphql/scalars/datetime/LocalTimeScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/LocalTimeScalarTest.groovy
@@ -2,14 +2,15 @@ package graphql.scalars.datetime
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.mkLocalT
+import static graphql.scalars.util.TestKit.mkStringValue
 
-class LocalTimeScalarTest extends Specification {
+class LocalTimeScalarTest extends AbstractScalarTest {
 
     def coercing = ExtendedScalars.LocalTime.getCoercing()
 
@@ -17,7 +18,7 @@ class LocalTimeScalarTest extends Specification {
     def "localtime parseValue"() {
 
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -32,7 +33,7 @@ class LocalTimeScalarTest extends Specification {
     def "localtime parseValue bad inputs"() {
 
         when:
-        coercing.parseValue(input)
+        coercing.parseValue(input, graphQLContext, locale)
         then:
         thrown(expectedValue)
         where:
@@ -45,7 +46,7 @@ class LocalTimeScalarTest extends Specification {
     def "localtime AST literal"() {
 
         when:
-        def result = coercing.parseLiteral(input)
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -59,7 +60,7 @@ class LocalTimeScalarTest extends Specification {
     def "localtime serialisation"() {
 
         when:
-        def result = coercing.serialize(input)
+        def result = coercing.serialize(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -70,10 +71,24 @@ class LocalTimeScalarTest extends Specification {
         mkLocalT("16:39:57.1") | "16:39:57.1"
     }
 
+    def "localtime valueToLiteral"() {
+
+        when:
+        def result = coercing.valueToLiteral(input, graphQLContext, locale)
+        then:
+        result.isEqualTo(expectedValue)
+
+        where:
+        input                | expectedValue
+        "23:20:50"           | mkStringValue("23:20:50")
+        "16:39"              | mkStringValue("16:39:00")
+        "12:00:27.999999999" | mkStringValue("12:00:27.999999999")
+    }
+
     def "datetime serialisation bad inputs"() {
 
         when:
-        coercing.serialize(input)
+        coercing.serialize(input, graphQLContext, locale)
         then:
         thrown(expectedValue)
         where:

--- a/src/test/groovy/graphql/scalars/datetime/NominalDurationScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/NominalDurationScalarTest.groovy
@@ -2,19 +2,20 @@ package graphql.scalars.datetime
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 
+import static graphql.scalars.util.TestKit.mkIntValue
 import static graphql.scalars.util.TestKit.mkPeriod
 import static graphql.scalars.util.TestKit.mkStringValue
 
-class NominalDurationScalarTest extends Specification {
+class NominalDurationScalarTest extends AbstractScalarTest {
 
     def coercing = ExtendedScalars.NominalDuration.getCoercing()
 
@@ -22,7 +23,7 @@ class NominalDurationScalarTest extends Specification {
     def "nominalduration parseValue"() {
 
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -39,7 +40,7 @@ class NominalDurationScalarTest extends Specification {
     def "nominalduration valueToLiteral"() {
 
         when:
-        def result = coercing.valueToLiteral(input)
+        def result = coercing.valueToLiteral(input, graphQLContext, locale)
         then:
         result.isEqualTo(expectedValue)
         where:
@@ -57,7 +58,7 @@ class NominalDurationScalarTest extends Specification {
     def "nominalduration parseValue bad inputs"() {
 
         when:
-        coercing.parseValue(input)
+        coercing.parseValue(input, graphQLContext, locale)
         then:
         thrown(expectedValue)
         where:
@@ -73,7 +74,7 @@ class NominalDurationScalarTest extends Specification {
     def "nominalduration AST literal"() {
 
         when:
-        def result = coercing.parseLiteral(input)
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -84,7 +85,7 @@ class NominalDurationScalarTest extends Specification {
     def "nominalduration serialisation"() {
 
         when:
-        def result = coercing.serialize(input)
+        def result = coercing.serialize(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -100,7 +101,7 @@ class NominalDurationScalarTest extends Specification {
     def "nominalduration serialisation bad inputs"() {
 
         when:
-        coercing.serialize(input)
+        coercing.serialize(input, graphQLContext, locale)
         then:
         thrown(expectedValue)
         where:
@@ -118,17 +119,16 @@ class NominalDurationScalarTest extends Specification {
     def "nominalduration parseLiteral bad inputs"() {
 
         when:
-        coercing.parseLiteral(input)
+        coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         thrown(expectedValue)
         where:
-        input                              | expectedValue
-        "PT1M"                             | CoercingParseLiteralException
-        "P1.5M"                            | CoercingParseLiteralException
-        "P1MT2H"                           | CoercingParseLiteralException
-        "PY"                               | CoercingParseLiteralException
-        123                                | CoercingParseLiteralException
-        ""                                 | CoercingParseLiteralException
-        Duration.of(1, ChronoUnit.MINUTES) | CoercingParseLiteralException
+        input                   | expectedValue
+        mkStringValue("PT1M")   | CoercingParseLiteralException
+        mkStringValue("P1.5M")  | CoercingParseLiteralException
+        mkStringValue("P1MT2H") | CoercingParseLiteralException
+        mkStringValue("PY")     | CoercingParseLiteralException
+        mkIntValue(123)         | CoercingParseLiteralException
+        mkStringValue("")       | CoercingParseLiteralException
     }
 }

--- a/src/test/groovy/graphql/scalars/datetime/SecondsSinceEpochScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/SecondsSinceEpochScalarTest.groovy
@@ -1,0 +1,135 @@
+package graphql.scalars.datetime
+
+import graphql.language.IntValue
+import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
+import graphql.schema.CoercingParseLiteralException
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
+import spock.lang.Unroll
+
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
+import static graphql.scalars.util.TestKit.mkIntValue
+import static graphql.scalars.util.TestKit.mkLocalDT
+import static graphql.scalars.util.TestKit.mkOffsetDT
+import static graphql.scalars.util.TestKit.mkStringValue
+import static graphql.scalars.util.TestKit.mkZonedDT
+
+class SecondsSinceEpochScalarTest extends AbstractScalarTest {
+
+    def coercing = ExtendedScalars.SecondsSinceEpoch.getCoercing()
+
+    @Unroll
+    def "secondsSinceEpoch parseValue"() {
+        when:
+        def result = coercing.parseValue(input, graphQLContext, locale)
+        then:
+        result.toEpochSecond() == expectedValue
+        where:
+        input        | expectedValue
+        "0"          | 0L
+        "1"          | 1L
+        "1609459200" | 1609459200L // 2021-01-01T00:00:00Z
+        "1640995200" | 1640995200L // 2022-01-01T00:00:00Z
+        0            | 0L
+        1            | 1L
+        1609459200   | 1609459200L // 2021-01-01T00:00:00Z
+        1640995200   | 1640995200L // 2022-01-01T00:00:00Z
+    }
+
+    @Unroll
+    def "secondsSinceEpoch valueToLiteral"() {
+        when:
+        def result = coercing.valueToLiteral(input, graphQLContext, locale)
+        then:
+        result.isEqualTo(expectedValue)
+        where:
+        input        | expectedValue
+        "0"          | mkIntValue(0)
+        "1"          | mkIntValue(1)
+        "1609459200" | mkIntValue(1609459200)
+        "1640995200" | mkIntValue(1640995200)
+        0            | mkIntValue(0)
+        1            | mkIntValue(1)
+        1609459200   | mkIntValue(1609459200)
+        1640995200   | mkIntValue(1640995200)
+        Instant.ofEpochSecond(1609459200) | mkIntValue(1609459200)
+        ZonedDateTime.ofInstant(Instant.ofEpochSecond(1609459200), ZoneOffset.UTC) | mkIntValue(1609459200)
+    }
+
+    @Unroll
+    def "secondsSinceEpoch parseValue bad inputs"() {
+        when:
+        coercing.parseValue(input, graphQLContext, locale)
+        then:
+        thrown(expectedValue)
+        where:
+        input                          | expectedValue
+        "not a number"                 | CoercingParseValueException
+        "123abc"                       | CoercingParseValueException
+        "2022-01-01"                   | CoercingParseValueException
+        "2022-01-01T00:00:00Z"         | CoercingParseValueException
+        new Object()                   | CoercingParseValueException
+    }
+
+    def "secondsSinceEpoch AST literal"() {
+        when:
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
+        then:
+        result.toEpochSecond() == expectedValue
+        where:
+        input                      | expectedValue
+        new StringValue("0")       | 0L
+        new StringValue("1")       | 1L
+        new StringValue("1609459200") | 1609459200L // 2021-01-01T00:00:00Z
+        new IntValue(0)            | 0L
+        new IntValue(1)            | 1L
+        new IntValue(1609459200)   | 1609459200L // 2021-01-01T00:00:00Z
+    }
+
+    def "secondsSinceEpoch serialisation"() {
+        when:
+        def result = coercing.serialize(input, graphQLContext, locale)
+        then:
+        result == expectedValue
+        where:
+        input                                                                  | expectedValue
+        Instant.ofEpochSecond(0)                                               | 0L
+        Instant.ofEpochSecond(1)                                               | 1L
+        Instant.ofEpochSecond(1609459200)                                      | 1609459200L
+        LocalDateTime.ofInstant(Instant.ofEpochSecond(1609459200), ZoneOffset.UTC) | 1609459200L
+        ZonedDateTime.ofInstant(Instant.ofEpochSecond(1609459200), ZoneOffset.UTC) | 1609459200L
+        OffsetDateTime.ofInstant(Instant.ofEpochSecond(1609459200), ZoneOffset.UTC) | 1609459200L
+    }
+
+    def "secondsSinceEpoch serialisation bad inputs"() {
+        when:
+        coercing.serialize(input, graphQLContext, locale)
+        then:
+        thrown(expectedValue)
+        where:
+        input                          | expectedValue
+        "not a temporal"               | CoercingSerializeException
+        new Object()                   | CoercingSerializeException
+    }
+
+    @Unroll
+    def "secondsSinceEpoch parseLiteral bad inputs"() {
+        when:
+        coercing.parseLiteral(input, variables, graphQLContext, locale)
+        then:
+        thrown(expectedValue)
+        where:
+        input                                | expectedValue
+        mkStringValue("not a number")        | CoercingParseLiteralException
+        mkStringValue("123abc")              | CoercingParseLiteralException
+        mkStringValue("2022-01-01")          | CoercingParseLiteralException
+        mkStringValue("2022-01-01T00:00:00Z")| CoercingParseLiteralException
+    }
+}

--- a/src/test/groovy/graphql/scalars/datetime/TimeScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/TimeScalarTest.groovy
@@ -2,9 +2,9 @@ package graphql.scalars.datetime
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.mkLocalDT
@@ -13,7 +13,7 @@ import static graphql.scalars.util.TestKit.mkOffsetT
 import static graphql.scalars.util.TestKit.mkStringValue
 import static graphql.scalars.util.TestKit.mkZonedDT
 
-class TimeScalarTest extends Specification {
+class TimeScalarTest extends AbstractScalarTest {
 
     def coercing = ExtendedScalars.Time.getCoercing()
 
@@ -21,7 +21,7 @@ class TimeScalarTest extends Specification {
     def "datetime parseValue"() {
 
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -37,7 +37,7 @@ class TimeScalarTest extends Specification {
     def "datetime parseValue bad inputs"() {
 
         when:
-        coercing.parseValue(input)
+        coercing.parseValue(input, graphQLContext, locale)
         then:
         thrown(expectedValue)
         where:
@@ -50,7 +50,7 @@ class TimeScalarTest extends Specification {
     def "datetime AST literal"() {
 
         when:
-        def result = coercing.parseLiteral(input)
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -61,7 +61,7 @@ class TimeScalarTest extends Specification {
     def "datetime serialisation"() {
 
         when:
-        def result = coercing.serialize(input)
+        def result = coercing.serialize(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -76,7 +76,7 @@ class TimeScalarTest extends Specification {
     def "datetime valueToLiteral"() {
 
         when:
-        def result = coercing.valueToLiteral(input)
+        def result = coercing.valueToLiteral(input, graphQLContext, locale)
         then:
         result.isEqualTo(expectedValue)
         where:
@@ -91,7 +91,7 @@ class TimeScalarTest extends Specification {
     def "datetime serialisation bad inputs"() {
 
         when:
-        coercing.serialize(input)
+        coercing.serialize(input, graphQLContext, locale)
         then:
         thrown(expectedValue)
         where:

--- a/src/test/groovy/graphql/scalars/datetime/YearMonthScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/YearMonthScalarTest.groovy
@@ -2,14 +2,14 @@ package graphql.scalars.datetime
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
-import spock.lang.Specification
+import graphql.scalars.util.AbstractScalarTest
 import spock.lang.Unroll
 
 import java.time.YearMonth
 
 import static graphql.scalars.util.TestKit.mkStringValue
 
-class YearMonthScalarTest extends Specification {
+class YearMonthScalarTest extends AbstractScalarTest {
 
     def coercing = ExtendedScalars.YearMonth.getCoercing()
 
@@ -17,48 +17,48 @@ class YearMonthScalarTest extends Specification {
     def "yearMonth parseValue"() {
 
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
-        input                           | expectedValue
-        "1937-01"                       | YearMonth.of(1937, 1)
+        input     | expectedValue
+        "1937-01" | YearMonth.of(1937, 1)
     }
 
     @Unroll
     def "yearMonth parseLiteral"() {
 
         when:
-        def result = coercing.parseLiteral(input)
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         result == expectedValue
         where:
-        input                         | expectedValue
-        new StringValue("1937-01")    | YearMonth.of(1937, 1)
+        input                      | expectedValue
+        new StringValue("1937-01") | YearMonth.of(1937, 1)
     }
 
     @Unroll
     def "yearMonth serialize"() {
 
         when:
-        def result = coercing.serialize(input)
+        def result = coercing.serialize(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
-        input                           | expectedValue
-        "1937-01"                       | "1937-01"
+        input     | expectedValue
+        "1937-01" | "1937-01"
     }
 
     @Unroll
     def "yearMonth valueToLiteral"() {
 
         when:
-        def result = coercing.valueToLiteral(input)
+        def result = coercing.valueToLiteral(input, graphQLContext, locale)
         then:
         result.isEqualTo(expectedValue)
         where:
-        input                           | expectedValue
-        "1937-01"                       | mkStringValue("1937-01")
+        input     | expectedValue
+        "1937-01" | mkStringValue("1937-01")
     }
 
 }

--- a/src/test/groovy/graphql/scalars/datetime/YearScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/datetime/YearScalarTest.groovy
@@ -2,14 +2,14 @@ package graphql.scalars.datetime
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
-import spock.lang.Specification
+import graphql.scalars.util.AbstractScalarTest
 import spock.lang.Unroll
 
 import java.time.Year
 
 import static graphql.scalars.util.TestKit.mkStringValue
 
-class YearScalarTest extends Specification {
+class YearScalarTest extends AbstractScalarTest {
 
     def coercing = ExtendedScalars.Year.getCoercing()
 
@@ -17,48 +17,48 @@ class YearScalarTest extends Specification {
     def "year parseValue"() {
 
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
-        input                           | expectedValue
-        "1937"                          | Year.of(1937)
+        input  | expectedValue
+        "1937" | Year.of(1937)
     }
 
     @Unroll
     def "year parseLiteral"() {
 
         when:
-        def result = coercing.parseLiteral(input)
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         result == expectedValue
         where:
-        input                         | expectedValue
-        new StringValue("1937")       | Year.of(1937)
+        input                   | expectedValue
+        new StringValue("1937") | Year.of(1937)
     }
 
     @Unroll
     def "year serialize"() {
 
         when:
-        def result = coercing.serialize(input)
+        def result = coercing.serialize(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
-        input                           | expectedValue
-        "1937"                          | "1937"
+        input  | expectedValue
+        "1937" | "1937"
     }
 
     @Unroll
     def "year valueToLiteral"() {
 
         when:
-        def result = coercing.valueToLiteral(input)
+        def result = coercing.valueToLiteral(input, graphQLContext, locale)
         then:
         result.isEqualTo(expectedValue)
         where:
-        input                           | expectedValue
-        "1937"                          | mkStringValue("1937")
+        input  | expectedValue
+        "1937" | mkStringValue("1937")
     }
 
 }

--- a/src/test/groovy/graphql/scalars/id/UUIDScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/id/UUIDScalarTest.groovy
@@ -2,16 +2,16 @@ package graphql.scalars.id
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.mkStringValue
 import static graphql.scalars.util.TestKit.mkUUIDValue
 
-class UUIDScalarTest extends Specification {
+class UUIDScalarTest extends AbstractScalarTest {
 
     def coercing = ExtendedScalars.UUID.getCoercing()
 
@@ -19,7 +19,7 @@ class UUIDScalarTest extends Specification {
     def "UUID parseValue"() {
 
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -32,7 +32,7 @@ class UUIDScalarTest extends Specification {
     def "UUID parseValue bad inputs"() {
 
         when:
-        coercing.parseValue(input)
+        coercing.parseValue(input, graphQLContext, locale)
         then:
         thrown(expectedValue)
         where:
@@ -45,7 +45,7 @@ class UUIDScalarTest extends Specification {
     def "UUID AST literal"() {
 
         when:
-        def result = coercing.parseLiteral(input)
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -56,7 +56,7 @@ class UUIDScalarTest extends Specification {
     def "UUID AST literal bad inputs"() {
 
         when:
-        coercing.parseLiteral(input)
+        coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         thrown(expectedValue)
         where:
@@ -67,7 +67,7 @@ class UUIDScalarTest extends Specification {
     def "UUID serialization"() {
 
         when:
-        def result = coercing.serialize(input)
+        def result = coercing.serialize(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -80,7 +80,7 @@ class UUIDScalarTest extends Specification {
     def "UUID serialization bad inputs"() {
 
         when:
-        coercing.serialize(input)
+        coercing.serialize(input, graphQLContext, locale)
         then:
         thrown(expectedValue)
         where:
@@ -93,7 +93,7 @@ class UUIDScalarTest extends Specification {
     def "UUID valueToLiteral"() {
 
         when:
-        def result = coercing.valueToLiteral(input)
+        def result = coercing.valueToLiteral(input, graphQLContext, locale)
         then:
         result.isEqualTo(expectedValue)
         where:

--- a/src/test/groovy/graphql/scalars/java/ScalarsBigDecimalTest.groovy
+++ b/src/test/groovy/graphql/scalars/java/ScalarsBigDecimalTest.groovy
@@ -1,24 +1,25 @@
 package graphql.scalars.java
 
+
 import graphql.language.BooleanValue
 import graphql.language.FloatValue
 import graphql.language.IntValue
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.util.concurrent.atomic.AtomicInteger
 
-class ScalarsBigDecimalTest extends Specification {
+class ScalarsBigDecimalTest extends AbstractScalarTest {
 
     @Unroll
     def "BigDecimal parse literal #literal.value as #result"() {
         expect:
-        ExtendedScalars.GraphQLBigDecimal.getCoercing().parseLiteral(literal) == result
+        ExtendedScalars.GraphQLBigDecimal.getCoercing().parseLiteral(literal, variables, graphQLContext, locale) == result
 
         where:
         literal                                 | result
@@ -31,7 +32,7 @@ class ScalarsBigDecimalTest extends Specification {
     @Unroll
     def "BigDecimal returns null for invalid #literal"() {
         when:
-        ExtendedScalars.GraphQLBigDecimal.getCoercing().parseLiteral(literal)
+        ExtendedScalars.GraphQLBigDecimal.getCoercing().parseLiteral(literal, variables, graphQLContext, locale)
         then:
         thrown(CoercingParseLiteralException)
 
@@ -44,30 +45,30 @@ class ScalarsBigDecimalTest extends Specification {
     @Unroll
     def "BigDecimal serialize #value into #result (#result.class)"() {
         expect:
-        ExtendedScalars.GraphQLBigDecimal.getCoercing().serialize(value) == result
-        ExtendedScalars.GraphQLBigDecimal.getCoercing().parseValue(value) == result
+        ExtendedScalars.GraphQLBigDecimal.getCoercing().serialize(value, graphQLContext, locale) == result
+        ExtendedScalars.GraphQLBigDecimal.getCoercing().parseValue(value, graphQLContext, locale) == result
 
         where:
-        value                 | result
-        "42"                  | new BigDecimal("42")
-        "42.123"              | new BigDecimal("42.123")
-        42.0000d              | new BigDecimal("42.000")
-        new Integer(42)       | new BigDecimal("42")
-        "-1"                  | new BigDecimal("-1")
-        new BigInteger(42)    | new BigDecimal("42")
-        new BigDecimal("42")  | new BigDecimal("42")
-        42.3f                 | new BigDecimal("42.3")
-        42.0d                 | new BigDecimal("42")
-        new Byte("42")        | new BigDecimal("42")
-        new Short("42")       | new BigDecimal("42")
-        1234567l              | new BigDecimal("1234567")
-        new AtomicInteger(42) | new BigDecimal("42")
+        value                  | result
+        "42"                   | new BigDecimal("42")
+        "42.123"               | new BigDecimal("42.123")
+        42.0000d               | new BigDecimal("42.000")
+        Integer.valueOf(42)    | new BigDecimal("42")
+        "-1"                   | new BigDecimal("-1")
+        BigInteger.valueOf(42) | new BigDecimal("42")
+        new BigDecimal("42")   | new BigDecimal("42")
+        42.3f                  | new BigDecimal("42.3")
+        42.0d                  | new BigDecimal("42")
+        Byte.valueOf("42")     | new BigDecimal("42")
+        Short.valueOf("42")    | new BigDecimal("42")
+        1234567l               | new BigDecimal("1234567")
+        new AtomicInteger(42)  | new BigDecimal("42")
     }
 
     @Unroll
     def "serialize throws exception for invalid input #value"() {
         when:
-        ExtendedScalars.GraphQLBigDecimal.getCoercing().serialize(value)
+        ExtendedScalars.GraphQLBigDecimal.getCoercing().serialize(value, graphQLContext, locale)
         then:
         thrown(CoercingSerializeException)
 
@@ -81,7 +82,7 @@ class ScalarsBigDecimalTest extends Specification {
     @Unroll
     def "parseValue throws exception for invalid input #value"() {
         when:
-        ExtendedScalars.GraphQLBigDecimal.getCoercing().parseValue(value)
+        ExtendedScalars.GraphQLBigDecimal.getCoercing().parseValue(value, graphQLContext, locale)
         then:
         thrown(CoercingParseValueException)
 

--- a/src/test/groovy/graphql/scalars/java/ScalarsBigIntegerTest.groovy
+++ b/src/test/groovy/graphql/scalars/java/ScalarsBigIntegerTest.groovy
@@ -1,25 +1,24 @@
 package graphql.scalars.java
 
-import graphql.Scalars
 import graphql.language.BooleanValue
 import graphql.language.FloatValue
 import graphql.language.IntValue
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.util.concurrent.atomic.AtomicInteger
 
-class ScalarsBigIntegerTest extends Specification {
+class ScalarsBigIntegerTest extends AbstractScalarTest {
 
     @Unroll
     def "BigInteger parse literal #literal.value as #result"() {
         expect:
-        ExtendedScalars.GraphQLBigInteger.getCoercing().parseLiteral(literal) == result
+        ExtendedScalars.GraphQLBigInteger.getCoercing().parseLiteral(literal, variables, graphQLContext, locale) == result
 
         where:
         literal                                 | result
@@ -31,7 +30,7 @@ class ScalarsBigIntegerTest extends Specification {
     @Unroll
     def "BigInteger returns null for invalid #literal"() {
         when:
-        ExtendedScalars.GraphQLBigInteger.getCoercing().parseLiteral(literal)
+        ExtendedScalars.GraphQLBigInteger.getCoercing().parseLiteral(literal, variables, graphQLContext, locale)
         then:
         thrown(CoercingParseLiteralException)
 
@@ -46,18 +45,18 @@ class ScalarsBigIntegerTest extends Specification {
     @Unroll
     def "BigInteger serialize #value into #result (#result.class)"() {
         expect:
-        ExtendedScalars.GraphQLBigInteger.getCoercing().serialize(value) == result
-        ExtendedScalars.GraphQLBigInteger.getCoercing().parseValue(value) == result
+        ExtendedScalars.GraphQLBigInteger.getCoercing().serialize(value, graphQLContext, locale) == result
+        ExtendedScalars.GraphQLBigInteger.getCoercing().parseValue(value, graphQLContext, locale) == result
 
         where:
         value                 | result
         "42"                  | new BigInteger("42")
-        new Integer(42)       | new BigInteger("42")
+        Integer.valueOf(42)   | new BigInteger("42")
         "-1"                  | new BigInteger("-1")
         new BigInteger("42")  | new BigInteger("42")
         42.0d                 | new BigInteger("42")
-        new Byte("42")        | new BigInteger("42")
-        new Short("42")       | new BigInteger("42")
+        Byte.valueOf("42")    | new BigInteger("42")
+        Short.valueOf("42")   | new BigInteger("42")
         1234567l              | new BigInteger("1234567")
         new AtomicInteger(42) | new BigInteger("42")
     }
@@ -65,7 +64,7 @@ class ScalarsBigIntegerTest extends Specification {
     @Unroll
     def "serialize throws exception for invalid input #value"() {
         when:
-        ExtendedScalars.GraphQLBigInteger.getCoercing().serialize(value)
+        ExtendedScalars.GraphQLBigInteger.getCoercing().serialize(value, graphQLContext, locale)
         then:
         thrown(CoercingSerializeException)
 
@@ -81,7 +80,7 @@ class ScalarsBigIntegerTest extends Specification {
     @Unroll
     def "parseValue throws exception for invalid input #value"() {
         when:
-        ExtendedScalars.GraphQLBigInteger.getCoercing().parseValue(value)
+        ExtendedScalars.GraphQLBigInteger.getCoercing().parseValue(value, graphQLContext, locale)
         then:
         thrown(CoercingParseValueException)
 

--- a/src/test/groovy/graphql/scalars/java/ScalarsByteTest.groovy
+++ b/src/test/groovy/graphql/scalars/java/ScalarsByteTest.groovy
@@ -1,23 +1,23 @@
 package graphql.scalars.java
 
-import graphql.scalars.ExtendedScalars
 import graphql.language.FloatValue
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.util.concurrent.atomic.AtomicInteger
 
-class ScalarsByteTest extends Specification {
+class ScalarsByteTest extends AbstractScalarTest {
 
     @Unroll
     def "Byte parse literal #literal.value as #result"() {
         expect:
-        ExtendedScalars.GraphQLByte.getCoercing().parseLiteral(literal) == result
+        ExtendedScalars.GraphQLByte.getCoercing().parseLiteral(literal, variables, graphQLContext, locale) == result
 
         where:
         literal                                    | result
@@ -30,7 +30,7 @@ class ScalarsByteTest extends Specification {
     @Unroll
     def "Byte returns null for invalid #literal"() {
         when:
-        ExtendedScalars.GraphQLByte.getCoercing().parseLiteral(literal)
+        ExtendedScalars.GraphQLByte.getCoercing().parseLiteral(literal, variables, graphQLContext, locale)
         then:
         thrown(CoercingParseLiteralException)
 
@@ -49,67 +49,67 @@ class ScalarsByteTest extends Specification {
     @Unroll
     def "Byte serialize #value into #result (#result.class)"() {
         expect:
-        ExtendedScalars.GraphQLByte.getCoercing().serialize(value) == result
-        ExtendedScalars.GraphQLByte.getCoercing().parseValue(value) == result
+        ExtendedScalars.GraphQLByte.getCoercing().serialize(value, graphQLContext, locale) == result
+        ExtendedScalars.GraphQLByte.getCoercing().parseValue(value, graphQLContext, locale) == result
 
         where:
-        value                 | result
-        "42"                  | 42
-        "42.0000"             | 42
-        42.0000d              | 42
-        new Integer(42)       | 42
-        "-1"                  | -1
-        new BigInteger(42)    | 42
-        new BigDecimal("42")  | 42
-        42.0f                 | 42
-        42.0d                 | 42
-        new Byte("42")        | 42
-        new Short("42")       | 42
-        123l                  | 123
-        new AtomicInteger(42) | 42
-        Byte.MAX_VALUE        | Byte.MAX_VALUE
-        Byte.MIN_VALUE        | Byte.MIN_VALUE
+        value                  | result
+        "42"                   | 42
+        "42.0000"              | 42
+        42.0000d               | 42
+        Integer.valueOf(42)    | 42
+        "-1"                   | -1
+        BigInteger.valueOf(42) | 42
+        new BigDecimal("42")   | 42
+        42.0f                  | 42
+        42.0d                  | 42
+        Byte.valueOf("42")     | 42
+        Short.valueOf("42")    | 42
+        123l                   | 123
+        new AtomicInteger(42)  | 42
+        Byte.MAX_VALUE         | Byte.MAX_VALUE
+        Byte.MIN_VALUE         | Byte.MIN_VALUE
     }
 
     @Unroll
     def "serialize throws exception for invalid input #value"() {
         when:
-        ExtendedScalars.GraphQLByte.getCoercing().serialize(value)
+        ExtendedScalars.GraphQLByte.getCoercing().serialize(value, graphQLContext, locale)
         then:
         thrown(CoercingSerializeException)
 
         where:
-        value                        | _
-        ""                           | _
-        "not a number "              | _
-        "42.3"                       | _
-        new Long(42345784398534785l) | _
-        new Double(42.3)             | _
-        new Float(42.3)              | _
-        Byte.MAX_VALUE + 1l          | _
-        Byte.MIN_VALUE - 1l          | _
-        new Object()                 | _
+        value                            | _
+        ""                               | _
+        "not a number "                  | _
+        "42.3"                           | _
+        Long.valueOf(42345784398534785l) | _
+        Double.valueOf(42.3)             | _
+        Float.valueOf(42.3)              | _
+        Byte.MAX_VALUE + 1l              | _
+        Byte.MIN_VALUE - 1l              | _
+        new Object()                     | _
 
     }
 
     @Unroll
     def "parseValue throws exception for invalid input #value"() {
         when:
-        ExtendedScalars.GraphQLByte.getCoercing().parseValue(value)
+        ExtendedScalars.GraphQLByte.getCoercing().parseValue(value, graphQLContext, locale)
         then:
         thrown(CoercingParseValueException)
 
         where:
-        value                        | _
-        ""                           | _
-        "not a number "              | _
-        "42.3"                       | _
-        new Long(42345784398534785l) | _
-        new Double(42.3)             | _
-        new Float(42.3)              | _
-        Byte.MAX_VALUE + 1l          | _
-        Byte.MIN_VALUE - 1l          | _
-        new Object()                 | _
+        value                            | _
+        ""                               | _
+        "not a number "                  | _
+        "42.3"                           | _
+        Long.valueOf(42345784398534785l) | _
+        Double.valueOf(42.3)             | _
+        Float.valueOf(42.3)              | _
+        Byte.MAX_VALUE + 1l              | _
+        Byte.MIN_VALUE - 1l              | _
+        new Object()                     | _
 
     }
 

--- a/src/test/groovy/graphql/scalars/java/ScalarsCharTest.groovy
+++ b/src/test/groovy/graphql/scalars/java/ScalarsCharTest.groovy
@@ -1,20 +1,20 @@
 package graphql.scalars.java
 
-import graphql.scalars.ExtendedScalars
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
-class ScalarsCharTest extends Specification {
+class ScalarsCharTest extends AbstractScalarTest {
 
     @Unroll
     def "Char parse literal #literal.value as #result"() {
         expect:
-        ExtendedScalars.GraphQLChar.getCoercing().parseLiteral(literal) == result
+        ExtendedScalars.GraphQLChar.getCoercing().parseLiteral(literal, variables, graphQLContext, locale) == result
 
         where:
         literal              | result
@@ -26,7 +26,7 @@ class ScalarsCharTest extends Specification {
     @Unroll
     def "Short returns null for invalid #literal"() {
         when:
-        ExtendedScalars.GraphQLChar.getCoercing().parseLiteral(literal)
+        ExtendedScalars.GraphQLChar.getCoercing().parseLiteral(literal, variables, graphQLContext, locale)
         then:
         thrown(CoercingParseLiteralException)
 
@@ -39,8 +39,8 @@ class ScalarsCharTest extends Specification {
     @Unroll
     def "Short serialize #value into #result (#result.class)"() {
         expect:
-        ExtendedScalars.GraphQLChar.getCoercing().serialize(value) == result
-        ExtendedScalars.GraphQLChar.getCoercing().parseValue(value) == result
+        ExtendedScalars.GraphQLChar.getCoercing().serialize(value, graphQLContext, locale) == result
+        ExtendedScalars.GraphQLChar.getCoercing().parseValue(value, graphQLContext, locale) == result
 
         where:
         value | result
@@ -51,7 +51,7 @@ class ScalarsCharTest extends Specification {
     @Unroll
     def "serialize throws exception for invalid input #value"() {
         when:
-        ExtendedScalars.GraphQLChar.getCoercing().serialize(value)
+        ExtendedScalars.GraphQLChar.getCoercing().serialize(value, graphQLContext, locale)
         then:
         thrown(CoercingSerializeException)
 
@@ -66,7 +66,7 @@ class ScalarsCharTest extends Specification {
     @Unroll
     def "parseValue throws exception for invalid input #value"() {
         when:
-        ExtendedScalars.GraphQLChar.getCoercing().parseValue(value)
+        ExtendedScalars.GraphQLChar.getCoercing().parseValue(value, graphQLContext, locale)
         then:
         thrown(CoercingParseValueException)
 

--- a/src/test/groovy/graphql/scalars/java/ScalarsLongTest.groovy
+++ b/src/test/groovy/graphql/scalars/java/ScalarsLongTest.groovy
@@ -1,19 +1,19 @@
 package graphql.scalars.java
 
-import graphql.scalars.ExtendedScalars
 import graphql.language.FloatValue
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
 import spock.lang.Shared
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.util.concurrent.atomic.AtomicInteger
 
-class ScalarsLongTest extends Specification {
+class ScalarsLongTest extends AbstractScalarTest {
 
     @Shared
     def tooBig = new BigInteger(Long.toString(Long.MAX_VALUE)).add(new BigInteger("1"))
@@ -23,7 +23,7 @@ class ScalarsLongTest extends Specification {
     @Unroll
     def "Long parse literal #literal.value as #result"() {
         expect:
-        ExtendedScalars.GraphQLLong.getCoercing().parseLiteral(literal) == result
+        ExtendedScalars.GraphQLLong.getCoercing().parseLiteral(literal, variables, graphQLContext, locale) == result
 
         where:
         literal                                    | result
@@ -38,7 +38,7 @@ class ScalarsLongTest extends Specification {
     @Unroll
     def "Long returns null for invalid #literal"() {
         when:
-        ExtendedScalars.GraphQLLong.getCoercing().parseLiteral(literal)
+        ExtendedScalars.GraphQLLong.getCoercing().parseLiteral(literal, variables, graphQLContext, locale)
         then:
         thrown(CoercingParseLiteralException)
 
@@ -46,73 +46,70 @@ class ScalarsLongTest extends Specification {
         literal                         | _
         new StringValue("not a number") | _
         new FloatValue(42.3)            | _
-        tooBig                          | null
-        tooSmall                        | null
-        new FloatValue(42.3)            | null
     }
 
     @Unroll
     def "Long serialize #value into #result (#result.class)"() {
         expect:
-        ExtendedScalars.GraphQLLong.getCoercing().serialize(value) == result
-        ExtendedScalars.GraphQLLong.getCoercing().parseValue(value) == result
+        ExtendedScalars.GraphQLLong.getCoercing().serialize(value, graphQLContext, locale) == result
+        ExtendedScalars.GraphQLLong.getCoercing().parseValue(value, graphQLContext, locale) == result
 
         where:
-        value                        | result
-        "42"                         | 42
-        "42.0000"                    | 42
-        42.0000d                     | 42
-        new Integer(42)              | 42
-        "-1"                         | -1
-        new BigInteger(42)           | 42
-        new BigDecimal("42")         | 42
-        42.0f                        | 42
-        42.0d                        | 42
-        new Byte("42")               | 42
-        new Short("42")              | 42
-        12345678910l                 | 12345678910l
-        new AtomicInteger(42)        | 42
-        Long.MAX_VALUE               | Long.MAX_VALUE
-        Long.MIN_VALUE               | Long.MIN_VALUE
-        new Long(42345784398534785l) | 42345784398534785l
+        value                            | result
+        "42"                             | 42
+        "42.0000"                        | 42
+        42.0000d                         | 42
+        Integer.valueOf(42)              | 42
+        "-1"                             | -1
+        BigInteger.valueOf(42)           | 42
+        new BigDecimal("42")             | 42
+        42.0f                            | 42
+        42.0d                            | 42
+        Byte.valueOf("42")               | 42
+        Short.valueOf("42")              | 42
+        12345678910l                     | 12345678910l
+        new AtomicInteger(42)            | 42
+        Long.MAX_VALUE                   | Long.MAX_VALUE
+        Long.MIN_VALUE                   | Long.MIN_VALUE
+        Long.valueOf(42345784398534785l) | 42345784398534785l
     }
 
     @Unroll
     def "serialize throws exception for invalid input #value"() {
         when:
-        ExtendedScalars.GraphQLLong.getCoercing().serialize(value)
+        ExtendedScalars.GraphQLLong.getCoercing().serialize(value, graphQLContext, locale)
         then:
         thrown(CoercingSerializeException)
 
         where:
-        value            | _
-        ""               | _
-        "not a number "  | _
-        "42.3"           | _
-        new Double(42.3) | _
-        new Float(42.3)  | _
-        tooBig           | _
-        tooSmall         | _
-        new Object()     | _
+        value                | _
+        ""                   | _
+        "not a number "      | _
+        "42.3"               | _
+        Double.valueOf(42.3) | _
+        Float.valueOf(42.3)  | _
+        tooBig               | _
+        tooSmall             | _
+        new Object()         | _
     }
 
     @Unroll
     def "parseValue throws exception for invalid input #value"() {
         when:
-        ExtendedScalars.GraphQLLong.getCoercing().parseValue(value)
+        ExtendedScalars.GraphQLLong.getCoercing().parseValue(value, graphQLContext, locale)
         then:
         thrown(CoercingParseValueException)
 
         where:
-        value            | _
-        ""               | _
-        "not a number "  | _
-        "42.3"           | _
-        new Double(42.3) | _
-        new Float(42.3)  | _
-        tooBig           | _
-        tooSmall         | _
-        new Object()     | _
+        value                | _
+        ""                   | _
+        "not a number "      | _
+        "42.3"               | _
+        Double.valueOf(42.3) | _
+        Float.valueOf(42.3)  | _
+        tooBig               | _
+        tooSmall             | _
+        new Object()         | _
     }
 
 }

--- a/src/test/groovy/graphql/scalars/java/ScalarsShortTest.groovy
+++ b/src/test/groovy/graphql/scalars/java/ScalarsShortTest.groovy
@@ -1,23 +1,24 @@
 package graphql.scalars.java
 
+
 import graphql.language.FloatValue
 import graphql.language.IntValue
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.util.concurrent.atomic.AtomicInteger
 
-class ScalarsShortTest extends Specification {
+class ScalarsShortTest extends AbstractScalarTest {
 
     @Unroll
     def "Short parse literal #literal.value as #result"() {
         expect:
-        ExtendedScalars.GraphQLShort.getCoercing().parseLiteral(literal) == result
+        ExtendedScalars.GraphQLShort.getCoercing().parseLiteral(literal, variables, graphQLContext, locale) == result
 
         where:
         literal                                     | result
@@ -30,7 +31,7 @@ class ScalarsShortTest extends Specification {
     @Unroll
     def "Short returns null for invalid #literal"() {
         when:
-        ExtendedScalars.GraphQLShort.getCoercing().parseLiteral(literal)
+        ExtendedScalars.GraphQLShort.getCoercing().parseLiteral(literal, variables, graphQLContext, locale)
         then:
         thrown(CoercingParseLiteralException)
 
@@ -48,32 +49,32 @@ class ScalarsShortTest extends Specification {
     @Unroll
     def "Short serialize #value into #result (#result.class)"() {
         expect:
-        ExtendedScalars.GraphQLShort.getCoercing().serialize(value) == result
-        ExtendedScalars.GraphQLShort.getCoercing().parseValue(value) == result
+        ExtendedScalars.GraphQLShort.getCoercing().serialize(value, graphQLContext, locale) == result
+        ExtendedScalars.GraphQLShort.getCoercing().parseValue(value, graphQLContext, locale) == result
 
         where:
-        value                 | result
-        "42"                  | 42
-        "42.0000"             | 42
-        42.0000d              | 42
-        new Integer(42)       | 42
-        "-1"                  | -1
-        new BigInteger(42)    | 42
-        new BigDecimal("42")  | 42
-        42.0f                 | 42
-        42.0d                 | 42
-        new Byte("42")        | 42
-        new Short("42")       | 42
-        1234l                 | 1234
-        new AtomicInteger(42) | 42
-        Short.MAX_VALUE       | Short.MAX_VALUE
-        Short.MIN_VALUE       | Short.MIN_VALUE
+        value                  | result
+        "42"                   | 42
+        "42.0000"              | 42
+        42.0000d               | 42
+        Integer.valueOf(42)    | 42
+        "-1"                   | -1
+        BigInteger.valueOf(42) | 42
+        new BigDecimal("42")   | 42
+        42.0f                  | 42
+        42.0d                  | 42
+        Byte.valueOf("42")     | 42
+        Short.valueOf("42")    | 42
+        1234l                  | 1234
+        new AtomicInteger(42)  | 42
+        Short.MAX_VALUE        | Short.MAX_VALUE
+        Short.MIN_VALUE        | Short.MIN_VALUE
     }
 
     @Unroll
     def "serialize throws exception for invalid input #value"() {
         when:
-        ExtendedScalars.GraphQLShort.getCoercing().serialize(value)
+        ExtendedScalars.GraphQLShort.getCoercing().serialize(value, graphQLContext, locale)
         then:
         thrown(CoercingSerializeException)
 
@@ -94,7 +95,7 @@ class ScalarsShortTest extends Specification {
     @Unroll
     def "parseValue throws exception for invalid input #value"() {
         when:
-        ExtendedScalars.GraphQLShort.getCoercing().parseValue(value)
+        ExtendedScalars.GraphQLShort.getCoercing().parseValue(value, graphQLContext, locale)
         then:
         thrown(CoercingParseValueException)
 

--- a/src/test/groovy/graphql/scalars/locale/LocaleScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/locale/LocaleScalarTest.groovy
@@ -2,13 +2,13 @@ package graphql.scalars.locale
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
-import spock.lang.Specification
+import graphql.scalars.util.AbstractScalarTest
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.mkLocale
 import static graphql.scalars.util.TestKit.mkStringValue
 
-class LocaleScalarTest extends Specification {
+class LocaleScalarTest extends AbstractScalarTest {
 
     def coercing = ExtendedScalars.Locale.getCoercing()
 
@@ -16,7 +16,7 @@ class LocaleScalarTest extends Specification {
     def "full locale parseValue"() {
 
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -30,7 +30,7 @@ class LocaleScalarTest extends Specification {
     @Unroll
     def "full Locale parseLiteral"() {
         when:
-        def result = coercing.parseLiteral(input)
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -41,7 +41,7 @@ class LocaleScalarTest extends Specification {
     @Unroll
     def "full Locale serialization"() {
         when:
-        def result = coercing.serialize(input)
+        def result = coercing.serialize(input, graphQLContext, locale)
         then:
         result == expectedValue
         where:
@@ -54,7 +54,7 @@ class LocaleScalarTest extends Specification {
     @Unroll
     def "full Locale valueToLiteral"() {
         when:
-        def result = coercing.valueToLiteral(input)
+        def result = coercing.valueToLiteral(input, graphQLContext, locale)
         then:
         result.isEqualTo(expectedValue)
         where:

--- a/src/test/groovy/graphql/scalars/numeric/NegativeFloatScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/numeric/NegativeFloatScalarTest.groovy
@@ -1,19 +1,18 @@
 package graphql.scalars.numeric
 
-
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.assertValueOrException
 import static graphql.scalars.util.TestKit.mkFloatValue
 import static graphql.scalars.util.TestKit.mkIntValue
 
-class NegativeFloatScalarTest extends Specification {
+class NegativeFloatScalarTest extends AbstractScalarTest {
     def coercing = ExtendedScalars.NegativeFloat.getCoercing()
 
     @Unroll
@@ -21,7 +20,7 @@ class NegativeFloatScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.serialize(input)
+            result = coercing.serialize(input, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }
@@ -43,7 +42,7 @@ class NegativeFloatScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.parseValue(input)
+            result = coercing.parseValue(input, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }
@@ -65,7 +64,7 @@ class NegativeFloatScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.parseLiteral(input)
+            result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }

--- a/src/test/groovy/graphql/scalars/numeric/NegativeIntScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/numeric/NegativeIntScalarTest.groovy
@@ -2,16 +2,16 @@ package graphql.scalars.numeric
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.assertValueOrException
 import static graphql.scalars.util.TestKit.mkIntValue
 
-class NegativeIntScalarTest extends Specification {
+class NegativeIntScalarTest extends AbstractScalarTest {
     def coercing = ExtendedScalars.NegativeInt.getCoercing()
 
     @Unroll
@@ -19,7 +19,7 @@ class NegativeIntScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.serialize(input)
+            result = coercing.serialize(input, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }
@@ -39,7 +39,7 @@ class NegativeIntScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.parseValue(input)
+            result = coercing.parseValue(input, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }
@@ -59,7 +59,7 @@ class NegativeIntScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.parseLiteral(input)
+            result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }

--- a/src/test/groovy/graphql/scalars/numeric/NonNegativeFloatScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/numeric/NonNegativeFloatScalarTest.groovy
@@ -2,17 +2,17 @@ package graphql.scalars.numeric
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.assertValueOrException
 import static graphql.scalars.util.TestKit.mkFloatValue
 import static graphql.scalars.util.TestKit.mkIntValue
 
-class NonNegativeFloatScalarTest extends Specification {
+class NonNegativeFloatScalarTest extends AbstractScalarTest {
     def coercing = ExtendedScalars.NonNegativeFloat.getCoercing()
 
     @Unroll
@@ -20,7 +20,7 @@ class NonNegativeFloatScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.serialize(input)
+            result = coercing.serialize(input, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }
@@ -42,7 +42,7 @@ class NonNegativeFloatScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.parseValue(input)
+            result = coercing.parseValue(input, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }
@@ -64,7 +64,7 @@ class NonNegativeFloatScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.parseLiteral(input)
+            result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }

--- a/src/test/groovy/graphql/scalars/numeric/NonNegativeIntScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/numeric/NonNegativeIntScalarTest.groovy
@@ -2,16 +2,16 @@ package graphql.scalars.numeric
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.assertValueOrException
 import static graphql.scalars.util.TestKit.mkIntValue
 
-class NonNegativeIntScalarTest extends Specification {
+class NonNegativeIntScalarTest extends AbstractScalarTest {
     def coercing = ExtendedScalars.NonNegativeInt.getCoercing()
 
     @Unroll
@@ -19,7 +19,7 @@ class NonNegativeIntScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.serialize(input)
+            result = coercing.serialize(input, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }
@@ -39,7 +39,7 @@ class NonNegativeIntScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.parseValue(input)
+            result = coercing.parseValue(input, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }
@@ -59,7 +59,7 @@ class NonNegativeIntScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.parseLiteral(input)
+            result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }

--- a/src/test/groovy/graphql/scalars/numeric/NonPositiveFloatScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/numeric/NonPositiveFloatScalarTest.groovy
@@ -2,17 +2,17 @@ package graphql.scalars.numeric
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.assertValueOrException
 import static graphql.scalars.util.TestKit.mkFloatValue
 import static graphql.scalars.util.TestKit.mkIntValue
 
-class NonPositiveFloatScalarTest extends Specification {
+class NonPositiveFloatScalarTest extends AbstractScalarTest {
     def coercing = ExtendedScalars.NonPositiveFloat.getCoercing()
 
     @Unroll
@@ -20,7 +20,7 @@ class NonPositiveFloatScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.serialize(input)
+            result = coercing.serialize(input, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }
@@ -41,7 +41,7 @@ class NonPositiveFloatScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.parseValue(input)
+            result = coercing.parseValue(input, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }
@@ -62,7 +62,7 @@ class NonPositiveFloatScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.parseLiteral(input)
+            result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }

--- a/src/test/groovy/graphql/scalars/numeric/NonPositiveIntScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/numeric/NonPositiveIntScalarTest.groovy
@@ -2,16 +2,16 @@ package graphql.scalars.numeric
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.assertValueOrException
 import static graphql.scalars.util.TestKit.mkIntValue
 
-class NonPositiveIntScalarTest extends Specification {
+class NonPositiveIntScalarTest extends AbstractScalarTest {
     def coercing = ExtendedScalars.NonPositiveInt.getCoercing()
 
     @Unroll
@@ -19,7 +19,7 @@ class NonPositiveIntScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.serialize(input)
+            result = coercing.serialize(input, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }
@@ -39,7 +39,7 @@ class NonPositiveIntScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.parseValue(input)
+            result = coercing.parseValue(input, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }
@@ -59,7 +59,7 @@ class NonPositiveIntScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.parseLiteral(input)
+            result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }

--- a/src/test/groovy/graphql/scalars/numeric/PositiveFloatScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/numeric/PositiveFloatScalarTest.groovy
@@ -2,17 +2,17 @@ package graphql.scalars.numeric
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.assertValueOrException
 import static graphql.scalars.util.TestKit.mkFloatValue
 import static graphql.scalars.util.TestKit.mkIntValue
 
-class PositiveFloatScalarTest extends Specification {
+class PositiveFloatScalarTest extends AbstractScalarTest {
     def coercing = ExtendedScalars.PositiveFloat.getCoercing()
 
     @Unroll
@@ -20,7 +20,7 @@ class PositiveFloatScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.serialize(input)
+            result = coercing.serialize(input, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }
@@ -42,7 +42,7 @@ class PositiveFloatScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.parseValue(input)
+            result = coercing.parseValue(input, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }
@@ -64,7 +64,7 @@ class PositiveFloatScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.parseLiteral(input)
+            result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }

--- a/src/test/groovy/graphql/scalars/numeric/PositiveIntScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/numeric/PositiveIntScalarTest.groovy
@@ -2,16 +2,16 @@ package graphql.scalars.numeric
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.assertValueOrException
 import static graphql.scalars.util.TestKit.mkIntValue
 
-class PositiveIntScalarTest extends Specification {
+class PositiveIntScalarTest extends AbstractScalarTest {
     def coercing = ExtendedScalars.PositiveInt.getCoercing()
 
     @Unroll
@@ -19,7 +19,7 @@ class PositiveIntScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.serialize(input)
+            result = coercing.serialize(input, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }
@@ -38,7 +38,7 @@ class PositiveIntScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.parseValue(input)
+            result = coercing.parseValue(input, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }
@@ -57,7 +57,7 @@ class PositiveIntScalarTest extends Specification {
         def result
         when:
         try {
-            result = coercing.parseLiteral(input)
+            result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         } catch (Exception e) {
             result = e
         }

--- a/src/test/groovy/graphql/scalars/object/ObjectScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/object/ObjectScalarTest.groovy
@@ -12,46 +12,51 @@ import graphql.language.StringValue
 import graphql.language.Value
 import graphql.language.VariableReference
 import graphql.scalars.ExtendedScalars
-import spock.lang.Specification
+import graphql.scalars.util.AbstractScalarTest
 import spock.lang.Unroll
 
-class ObjectScalarTest extends Specification {
+class ObjectScalarTest extends AbstractScalarTest {
 
-    def variables = [
-            "varRef1": "value1"
-    ]
 
     def coercing = ExtendedScalars.Object.getCoercing()
+
+    @Override
+    void setup() {
+        variables = [
+                "varRef1": "value1"
+        ]
+
+    }
 
     @Unroll
     def "test AST parsing"() {
 
         when:
-        def result = coercing.parseLiteral(input, variables)
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         result == expectedResult
         where:
-        input                | expectedResult
-        mkStringValue("s")   | "s"
-        mkFloatValue("99.9") | new BigDecimal("99.9")
-        mkIntValue(666)      | 666
-        mkBooleanValue(true) | true
-        mkEnumValue("enum")  | "enum"
-        mkVarRef("varRef1")  | "value1"
+        input                                       | expectedResult
+        mkStringValue("s")                          | "s"
+        mkFloatValue("99.9")                        | new BigDecimal("99.9")
+        mkIntValue(666)                             | 666
+        mkBooleanValue(true)                        | true
+        mkEnumValue("enum")                         | "enum"
+        mkVarRef("varRef1")                         | "value1"
         mkArrayValue([
                 mkStringValue("s"), mkIntValue(666)
-        ] as List<Value>)    | ["s", 666]
+        ] as List<Value>)                           | ["s", 666]
     }
 
     @Unroll
     def "test AST object parsing"() {
 
         when:
-        def result = coercing.parseLiteral(input, variables)
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         result == expectedResult
         where:
-        input                    | expectedResult
+        input                                               | expectedResult
         mkObjectValue([
                 fld1: mkStringValue("s"),
                 fld2: mkIntValue(99),
@@ -59,17 +64,17 @@ class ObjectScalarTest extends Specification {
                         childFld1: mkStringValue("child1"),
                         childFl2 : mkVarRef("varRef1")
                 ] as Map<String, Value>)
-        ] as Map<String, Value>) | [fld1: "s", fld2: 99, fld3: [childFld1: "child1", childFl2: "value1"]]
+        ] as Map<String, Value>)                            | [fld1: "s", fld2: 99, fld3: [childFld1: "child1", childFl2: "value1"]]
 
         mkObjectValue([
                 field1: mkNullValue()
-        ] as Map<String, Value>) | [field1: null] // Nested NullValue inside ObjectValue
+        ] as Map<String, Value>)                            | [field1: null] // Nested NullValue inside ObjectValue
     }
 
     @Unroll
     def "test serialize is always in and out"() {
         when:
-        def result = coercing.serialize(input)
+        def result = coercing.serialize(input, graphQLContext, locale)
         then:
         result == expectedResult
         where:
@@ -81,7 +86,7 @@ class ObjectScalarTest extends Specification {
     @Unroll
     def "test parseValue is always in and out"() {
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         result == expectedResult
         where:
@@ -93,7 +98,7 @@ class ObjectScalarTest extends Specification {
     @Unroll
     def "test valueToLiteral #input"() {
         when:
-        def result = coercing.valueToLiteral(input)
+        def result = coercing.valueToLiteral(input, graphQLContext, locale)
         then:
         result.isEqualTo(expectedResult)
         where:

--- a/src/test/groovy/graphql/scalars/regex/RegexScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/regex/RegexScalarTest.groovy
@@ -2,18 +2,18 @@ package graphql.scalars.regex
 
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
 import graphql.schema.GraphQLScalarType
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.util.regex.Pattern
 
 import static graphql.scalars.util.TestKit.mkStringValue
 
-class RegexScalarTest extends Specification {
+class RegexScalarTest extends AbstractScalarTest {
 
     GraphQLScalarType phoneNumberScalar = ExtendedScalars.newRegexScalar("phoneNumber")
             .addPattern(Pattern.compile("\\([0-9]*\\)[0-9]*"))
@@ -23,7 +23,7 @@ class RegexScalarTest extends Specification {
     def "basic regex parseValue"() {
 
         when:
-        def result = phoneNumberScalar.getCoercing().parseValue(input)
+        def result = phoneNumberScalar.getCoercing().parseValue(input, graphQLContext, locale)
         then:
         result == expectedResult
         where:
@@ -34,7 +34,7 @@ class RegexScalarTest extends Specification {
     @Unroll
     def "basic regex parseValue bad input"() {
         when:
-        phoneNumberScalar.getCoercing().parseValue(input)
+        phoneNumberScalar.getCoercing().parseValue(input, graphQLContext, locale)
         then:
         thrown(expectedResult)
         where:
@@ -46,7 +46,7 @@ class RegexScalarTest extends Specification {
     def "basic regex parseLiteral"() {
 
         when:
-        def result = phoneNumberScalar.getCoercing().parseLiteral(input)
+        def result = phoneNumberScalar.getCoercing().parseLiteral(input, variables, graphQLContext, locale)
         then:
         result == expectedResult
         where:
@@ -57,19 +57,19 @@ class RegexScalarTest extends Specification {
     @Unroll
     def "basic regex parseLiteral bad input"() {
         when:
-        phoneNumberScalar.getCoercing().parseLiteral(input)
+        phoneNumberScalar.getCoercing().parseLiteral(input, variables, graphQLContext, locale)
         then:
         thrown(expectedResult)
         where:
-        input        || expectedResult
-        "(02)abc123" || CoercingParseLiteralException
+        input                       || expectedResult
+        mkStringValue("(02)abc123") || CoercingParseLiteralException
     }
 
     @Unroll
     def "basic regex serialize"() {
 
         when:
-        def result = phoneNumberScalar.getCoercing().serialize(input)
+        def result = phoneNumberScalar.getCoercing().serialize(input, graphQLContext, locale)
         then:
         result == expectedResult
         where:
@@ -81,7 +81,7 @@ class RegexScalarTest extends Specification {
     def "basic regex valueToLiteral"() {
 
         when:
-        def result = phoneNumberScalar.getCoercing().valueToLiteral(input)
+        def result = phoneNumberScalar.getCoercing().valueToLiteral(input, graphQLContext, locale)
         then:
         result.isEqualTo(expectedResult)
         where:
@@ -92,12 +92,12 @@ class RegexScalarTest extends Specification {
     @Unroll
     def "basic regex serialize bad input"() {
         when:
-        phoneNumberScalar.getCoercing().serialize(input)
+        phoneNumberScalar.getCoercing().serialize(input, graphQLContext, locale)
         then:
         thrown(expectedResult)
         where:
-        input        || expectedResult
-        "(02)abc123" || CoercingSerializeException
+        input                       || expectedResult
+        mkStringValue("(02)abc123") || CoercingSerializeException
     }
 
 }

--- a/src/test/groovy/graphql/scalars/url/UrlScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/url/UrlScalarTest.groovy
@@ -1,17 +1,18 @@
 package graphql.scalars.url
 
+
 import graphql.language.BooleanValue
 import graphql.language.StringValue
 import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import static graphql.scalars.util.TestKit.mkStringValue
 
-class UrlScalarTest extends Specification {
+class UrlScalarTest extends AbstractScalarTest {
 
     def coercing = ExtendedScalars.Url.getCoercing()
 
@@ -19,7 +20,7 @@ class UrlScalarTest extends Specification {
     def "test serialize"() {
 
         when:
-        def result = coercing.serialize(input)
+        def result = coercing.serialize(input, graphQLContext, locale)
         then:
         result == expectedResult
         where:
@@ -34,7 +35,7 @@ class UrlScalarTest extends Specification {
     def "test valueToLiteral"() {
 
         when:
-        def result = coercing.valueToLiteral(input)
+        def result = coercing.valueToLiteral(input, graphQLContext, locale)
         then:
         result.isEqualTo(expectedResult)
         where:
@@ -48,7 +49,7 @@ class UrlScalarTest extends Specification {
     @Unroll
     def "test serialize bad inputs"() {
         when:
-        coercing.serialize(input)
+        coercing.serialize(input, graphQLContext, locale)
         then:
         thrown(exceptionClas)
         where:
@@ -60,7 +61,7 @@ class UrlScalarTest extends Specification {
     @Unroll
     def "test parseValue"() {
         when:
-        def result = coercing.parseValue(input)
+        def result = coercing.parseValue(input, graphQLContext, locale)
         then:
         result == expectedResult
         where:
@@ -74,7 +75,7 @@ class UrlScalarTest extends Specification {
     @Unroll
     def "test parseValue bad inputs"() {
         when:
-        coercing.parseValue(input)
+        coercing.parseValue(input, graphQLContext, locale)
         then:
         thrown(exceptionClas)
         where:
@@ -86,7 +87,7 @@ class UrlScalarTest extends Specification {
     @Unroll
     def "test parseLiteral"() {
         when:
-        def result = coercing.parseLiteral(input)
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         result == expectedResult
         where:
@@ -97,7 +98,7 @@ class UrlScalarTest extends Specification {
     @Unroll
     def "test parseLiteral bad inputs"() {
         when:
-        coercing.parseLiteral(input)
+        coercing.parseLiteral(input, variables, graphQLContext, locale)
         then:
         thrown(exceptionClas)
         where:

--- a/src/test/groovy/graphql/scalars/util/AbstractScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/util/AbstractScalarTest.groovy
@@ -1,0 +1,22 @@
+package graphql.scalars.util
+
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
+import spock.lang.Specification
+
+/**
+ * Base class for scalar test
+ */
+abstract class AbstractScalarTest extends Specification {
+
+    GraphQLContext graphQLContext
+    Locale locale
+    CoercedVariables variables
+
+    void setup() {
+        graphQLContext = GraphQLContext.newContext().build()
+        locale = Locale.getDefault()
+        variables = CoercedVariables.emptyVariables()
+    }
+
+}

--- a/src/test/groovy/graphql/scalars/util/TestKit.groovy
+++ b/src/test/groovy/graphql/scalars/util/TestKit.groovy
@@ -5,8 +5,8 @@ import graphql.language.IntValue
 import graphql.language.StringValue
 import graphql.scalars.country.code.CountryCode
 
+import java.awt.*
 import java.time.Duration
-import java.awt.Color
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -119,6 +119,7 @@ class TestKit {
     static Color mkColor(int r, int g, int b, int a) {
         return new Color(r, g, b, a)
     }
+
     static Color mkColor(int r, int g, int b) {
         return new Color(r, g, b)
     }


### PR DESCRIPTION
It also addresses https://github.com/graphql-java/graphql-java-extended-scalars/issues/156

This started out to just add valueToLiteral to the one scalar but then I decided to updates them all to NOT use deprecated methods which then affected all tests.

So it kinda got away on me BUT there are no deprecated methods being used in the code base now