### PR TITLE
Add URI scalar

### DIFF
--- a/src/main/java/graphql/scalars/ExtendedScalars.java
+++ b/src/main/java/graphql/scalars/ExtendedScalars.java
@@ -28,6 +28,7 @@ import graphql.scalars.numeric.PositiveIntScalar;
 import graphql.scalars.object.JsonScalar;
 import graphql.scalars.object.ObjectScalar;
 import graphql.scalars.regex.RegexScalar;
+import graphql.scalars.uri.UriScalar;
 import graphql.scalars.url.UrlScalar;
 import graphql.schema.GraphQLScalarType;
 
@@ -208,6 +209,11 @@ public class ExtendedScalars {
      * @see graphql.scalars.ExtendedScalars#Object
      */
     public static final GraphQLScalarType Json = JsonScalar.INSTANCE;
+
+    /**
+     * A URI scalar that accepts URI strings and produces {@link java.net.URI} objects at runtime
+     */
+    public static final GraphQLScalarType Uri = UriScalar.INSTANCE;
 
     /**
      * A URL scalar that accepts URL strings and produces {@link java.net.URL} objects at runtime

--- a/src/main/java/graphql/scalars/uri/UriScalar.java
+++ b/src/main/java/graphql/scalars/uri/UriScalar.java
@@ -1,0 +1,118 @@
+package graphql.scalars.uri;
+
+import graphql.GraphQLContext;
+import graphql.Internal;
+import graphql.execution.CoercedVariables;
+import graphql.language.StringValue;
+import graphql.language.Value;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+import graphql.schema.GraphQLScalarType;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static graphql.scalars.util.Kit.typeName;
+
+@Internal
+public final class UriScalar {
+
+    private UriScalar() {
+    }
+
+    public static final GraphQLScalarType INSTANCE;
+
+    static {
+        Coercing<URL, URL> coercing = new Coercing<>() {
+            @Override
+            public URL serialize(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingSerializeException {
+                Optional<URL> url;
+                if (input instanceof String) {
+                    url = Optional.of(parseURL(input.toString(), CoercingSerializeException::new));
+                } else {
+                    url = toURL(input);
+                }
+                if (url.isPresent()) {
+                    return url.get();
+                }
+                throw new CoercingSerializeException(
+                        "Expected a 'URL' like object but was '" + typeName(input) + "'."
+                );
+            }
+
+            @Override
+            public URL parseValue(Object input, GraphQLContext graphQLContext, Locale locale) throws CoercingParseValueException {
+                String urlStr;
+                if (input instanceof String) {
+                    urlStr = String.valueOf(input);
+                } else {
+                    Optional<URL> url = toURL(input);
+                    if (url.isEmpty()) {
+                        throw new CoercingParseValueException(
+                                "Expected a 'URL' like object but was '" + typeName(input) + "'."
+                        );
+                    }
+                    return url.get();
+                }
+                return parseURL(urlStr, CoercingParseValueException::new);
+            }
+
+            @Override
+            public URL parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) throws CoercingParseLiteralException {
+                if (!(input instanceof StringValue)) {
+                    throw new CoercingParseLiteralException(
+                            "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
+                    );
+                }
+                return parseURL(((StringValue) input).getValue(), CoercingParseLiteralException::new);
+            }
+
+            @Override
+            public Value<?> valueToLiteral(Object input, GraphQLContext graphQLContext, Locale locale) {
+                URL url = serialize(input, graphQLContext, locale);
+                return StringValue.newStringValue(url.toExternalForm()).build();
+            }
+
+
+            private URL parseURL(String input, Function<String, RuntimeException> exceptionMaker) {
+                try {
+                    return new URI(input).toURL();
+                } catch (URISyntaxException | IllegalArgumentException | MalformedURLException e) {
+                    throw exceptionMaker.apply("Invalid URL value : '" + input + "'.");
+                }
+            }
+        };
+
+        INSTANCE = GraphQLScalarType.newScalar()
+                .name("Url")
+                .description("A Url scalar")
+                .coercing(coercing)
+                .build();
+    }
+
+    private static Optional<URL> toURL(Object input) {
+        if (input instanceof URL) {
+            return Optional.of((URL) input);
+        } else if (input instanceof URI) {
+            try {
+                return Optional.of(((URI) input).toURL());
+            } catch (MalformedURLException ignored) {
+            }
+        } else if (input instanceof File) {
+            try {
+                return Optional.of(((File) input).toURI().toURL());
+            } catch (MalformedURLException ignored) {
+            }
+        }
+        return Optional.empty();
+    }
+
+}

--- a/src/test/groovy/graphql/scalars/uri/UriScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/uri/UriScalarTest.groovy
@@ -1,0 +1,111 @@
+package graphql.scalars.uri
+
+
+import graphql.language.BooleanValue
+import graphql.language.StringValue
+import graphql.scalars.ExtendedScalars
+import graphql.scalars.util.AbstractScalarTest
+import graphql.schema.CoercingParseLiteralException
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
+import spock.lang.Unroll
+
+import static graphql.scalars.util.TestKit.mkStringValue
+
+class UriScalarTest extends AbstractScalarTest {
+
+    def coercing = ExtendedScalars.Uri.getCoercing()
+
+    @Unroll
+    def "test serialize"() {
+
+        when:
+        def result = coercing.serialize(input, graphQLContext, locale)
+        then:
+        result == expectedResult
+        where:
+        input                                   | expectedResult
+        new URL("http://www.graphql-java.com/") | new URL("http://www.graphql-java.com/")
+        new URI("http://www.graphql-java.com/") | new URL("http://www.graphql-java.com/")
+        new File("/this/that")                  | new URL("file:/this/that")
+        "http://www.graphql-java.com/"          | new URL("http://www.graphql-java.com/")
+    }
+
+    @Unroll
+    def "test valueToLiteral"() {
+
+        when:
+        def result = coercing.valueToLiteral(input, graphQLContext, locale)
+        then:
+        result.isEqualTo(expectedResult)
+        where:
+        input                                   | expectedResult
+        new URL("http://www.graphql-java.com/") | mkStringValue("http://www.graphql-java.com/")
+        new URI("http://www.graphql-java.com/") | mkStringValue("http://www.graphql-java.com/")
+        new File("/this/that")                  | mkStringValue("file:/this/that")
+        "http://www.graphql-java.com/"          | mkStringValue("http://www.graphql-java.com/")
+    }
+
+    @Unroll
+    def "test serialize bad inputs"() {
+        when:
+        coercing.serialize(input, graphQLContext, locale)
+        then:
+        thrown(exceptionClas)
+        where:
+        input       || exceptionClas
+        666         || CoercingSerializeException
+        "not/a/url" || CoercingSerializeException
+    }
+
+    @Unroll
+    def "test parseValue"() {
+        when:
+        def result = coercing.parseValue(input, graphQLContext, locale)
+        then:
+        result == expectedResult
+        where:
+        input                                   | expectedResult
+        new URL("http://www.graphql-java.com/") | new URL("http://www.graphql-java.com/")
+        new URI("http://www.graphql-java.com/") | new URL("http://www.graphql-java.com/")
+        new File("/this/that")                  | new URL("file:/this/that")
+        "http://www.graphql-java.com/"          | new URL("http://www.graphql-java.com/")
+    }
+
+    @Unroll
+    def "test parseValue bad inputs"() {
+        when:
+        coercing.parseValue(input, graphQLContext, locale)
+        then:
+        thrown(exceptionClas)
+        where:
+        input       || exceptionClas
+        666         || CoercingParseValueException
+        "not/a/url" || CoercingParseValueException
+    }
+
+    @Unroll
+    def "test parseLiteral"() {
+        when:
+        def result = coercing.parseLiteral(input, variables, graphQLContext, locale)
+        then:
+        result == expectedResult
+        where:
+        input                                           | expectedResult
+        new StringValue("http://www.graphql-java.com/") | new URL("http://www.graphql-java.com/")
+    }
+
+    @Unroll
+    def "test parseLiteral bad inputs"() {
+        when:
+        coercing.parseLiteral(input, variables, graphQLContext, locale)
+        then:
+        thrown(exceptionClas)
+        where:
+        input                        | exceptionClas
+        new BooleanValue(true)       | CoercingParseLiteralException
+        new StringValue("1:not/a/uri") | CoercingParseLiteralException
+    }
+
+
+}

--- a/src/test/groovy/graphql/scalars/uri/UriScalarTest.groovy
+++ b/src/test/groovy/graphql/scalars/uri/UriScalarTest.groovy
@@ -25,10 +25,10 @@ class UriScalarTest extends AbstractScalarTest {
         result == expectedResult
         where:
         input                                   | expectedResult
-        new URL("http://www.graphql-java.com/") | new URL("http://www.graphql-java.com/")
-        new URI("http://www.graphql-java.com/") | new URL("http://www.graphql-java.com/")
-        new File("/this/that")                  | new URL("file:/this/that")
-        "http://www.graphql-java.com/"          | new URL("http://www.graphql-java.com/")
+        new URL("http://www.graphql-java.com/") | new URI("http://www.graphql-java.com/")
+        new URI("http://www.graphql-java.com/") | new URI("http://www.graphql-java.com/")
+        new File("/this/that")                  | new URI("file:/this/that")
+        "http://www.graphql-java.com/"          | new URI("http://www.graphql-java.com/")
     }
 
     @Unroll
@@ -53,9 +53,9 @@ class UriScalarTest extends AbstractScalarTest {
         then:
         thrown(exceptionClas)
         where:
-        input       || exceptionClas
-        666         || CoercingSerializeException
-        "not/a/url" || CoercingSerializeException
+        input         || exceptionClas
+        666           || CoercingSerializeException
+        "1:not/a/uri" || CoercingSerializeException
     }
 
     @Unroll
@@ -66,10 +66,10 @@ class UriScalarTest extends AbstractScalarTest {
         result == expectedResult
         where:
         input                                   | expectedResult
-        new URL("http://www.graphql-java.com/") | new URL("http://www.graphql-java.com/")
-        new URI("http://www.graphql-java.com/") | new URL("http://www.graphql-java.com/")
-        new File("/this/that")                  | new URL("file:/this/that")
-        "http://www.graphql-java.com/"          | new URL("http://www.graphql-java.com/")
+        new URL("http://www.graphql-java.com/") | new URI("http://www.graphql-java.com/")
+        new URI("http://www.graphql-java.com/") | new URI("http://www.graphql-java.com/")
+        new File("/this/that")                  | new URI("file:/this/that")
+        "http://www.graphql-java.com/"          | new URI("http://www.graphql-java.com/")
     }
 
     @Unroll
@@ -79,9 +79,9 @@ class UriScalarTest extends AbstractScalarTest {
         then:
         thrown(exceptionClas)
         where:
-        input       || exceptionClas
-        666         || CoercingParseValueException
-        "not/a/url" || CoercingParseValueException
+        input         || exceptionClas
+        666           || CoercingParseValueException
+        "1:not/a/url" || CoercingParseValueException
     }
 
     @Unroll
@@ -92,7 +92,7 @@ class UriScalarTest extends AbstractScalarTest {
         result == expectedResult
         where:
         input                                           | expectedResult
-        new StringValue("http://www.graphql-java.com/") | new URL("http://www.graphql-java.com/")
+        new StringValue("http://www.graphql-java.com/") | new URI("http://www.graphql-java.com/")
     }
 
     @Unroll
@@ -102,9 +102,9 @@ class UriScalarTest extends AbstractScalarTest {
         then:
         thrown(exceptionClas)
         where:
-        input                        | exceptionClas
-        new BooleanValue(true)       | CoercingParseLiteralException
-        new StringValue("1:not/a/uri") | CoercingParseLiteralException
+        input                          | exceptionClas
+        new BooleanValue(true)         | CoercingParseLiteralException
+        new StringValue("1:not/a/url") | CoercingParseLiteralException
     }
 
 


### PR DESCRIPTION
This PR introduces an URI scalar backed by `java.net.URI`.

As `java.net.URL` might perform unintended DNS lookups, one could prefer using `URI`s instead.
https://www.baeldung.com/java-url-vs-uri#3-opening-a-remote-connection

This is a blatant copy of the URL scalar, with necessary adjustments. I can put more effort into it if pointed out.

I've made two commits to make it easier comparing the adjustments: https://github.com/graphql-java/graphql-java-extended-scalars/pull/172/commits/e448beee3b0207db56f761d86166a4fd620810a1